### PR TITLE
refactor: remove obsolete tags calculation in TorrentListItem

### DIFF
--- a/lib/widgets/torrent_list_item.dart
+++ b/lib/widgets/torrent_list_item.dart
@@ -91,9 +91,6 @@ class TorrentListItem extends StatelessWidget {
     final showCover = siteShowCover && (showCoverSetting ?? true);
 
     // 统一计算标签与清理后的描述，避免重复调用
-
-    // final tags = TagType.matchTags(descrRef);
-    // 这里的tags已经在adapter中计算好了，直接使用
     final tags = torrent.tags;
 
     final hasDouban = _hasRatingValue(torrent.doubanRating);

--- a/test/widgets/torrent_list_item_tags_test.dart
+++ b/test/widgets/torrent_list_item_tags_test.dart
@@ -46,8 +46,7 @@ void main() {
     final torrent = TorrentItem(
       id: '1',
       name: 'Test Torrent',
-      smallDescr:
-          '4K 1080p HDR H265 WEB-DL DIY Blu-ray 4K 1080p HDR H265 WEB-DL DIY Blu-ray 4K 1080p HDR H265 WEB-DL DIY Blu-ray',
+      smallDescr: 'Test Description',
       sizeBytes: 1024,
       seeders: 10,
       leechers: 5,
@@ -56,13 +55,29 @@ void main() {
       downloadUrl: '',
       imageList: [],
       cover: '',
-
       downloadStatus: DownloadStatus.none,
       discount: DiscountType.normal,
       collection: false,
       isTop: false,
       doubanRating: '0',
       imdbRating: '0',
+      tags: [
+        TagType.fourK,
+        TagType.resolution1080,
+        TagType.hdr,
+        TagType.h265,
+        TagType.webDl,
+        TagType.dovi,
+        TagType.blueRay,
+        TagType.chinese,
+        TagType.complete,
+        TagType.diy,
+        TagType.ep,
+        TagType.hot,
+        TagType.official,
+        TagType.mandarin,
+        TagType.chineseTraditional,
+      ],
     );
 
     // Set screen size to small (e.g., 400px width)
@@ -87,8 +102,7 @@ void main() {
       final torrent = TorrentItem(
         id: '1',
         name: 'Test Torrent',
-        smallDescr:
-            'Tag1 Tag2 Tag3 Tag4 Tag5 Tag6 Tag7 Tag8 Tag9 Tag10 Tag11 Tag12 Tag13 Tag14 Tag15',
+        smallDescr: 'Test Description',
         sizeBytes: 1024,
         seeders: 10,
         leechers: 5,
@@ -97,13 +111,29 @@ void main() {
         downloadUrl: '',
         imageList: [],
         cover: '',
-
         downloadStatus: DownloadStatus.none,
         discount: DiscountType.normal,
         collection: false,
         isTop: false,
         doubanRating: '0',
         imdbRating: '0',
+        tags: [
+          TagType.fourK,
+          TagType.resolution1080,
+          TagType.hdr,
+          TagType.h265,
+          TagType.webDl,
+          TagType.dovi,
+          TagType.blueRay,
+          TagType.chinese,
+          TagType.complete,
+          TagType.diy,
+          TagType.ep,
+          TagType.hot,
+          TagType.official,
+          TagType.mandarin,
+          TagType.chineseTraditional,
+        ],
       );
 
       // Set screen size to large (e.g., 1000px width)


### PR DESCRIPTION
Removed obsolete commented-out code in `TorrentListItem` and updated related tests to reflect the current architecture where tags are pre-calculated.

---
*PR created automatically by Jules for task [4249494088983963764](https://jules.google.com/task/4249494088983963764) started by @JustLookAtNow*