### PR TITLE
⚡ Optimize StorageService caching to prevent redundant JSON decoding

### DIFF
--- a/lib/services/storage/storage_service.dart
+++ b/lib/services/storage/storage_service.dart
@@ -481,8 +481,6 @@ class StorageService {
       await _saveSiteApiKey(config.id, config.apiKey);
       _siteApiKeysCache[config.id] = config.apiKey; // 更新缓存
     }
-    // 站点配置已变更，标记缓存需重新解析（下次 loadSiteConfigs ）
-    _siteConfigsCacheDirty = true;
   }
 
   Future<void> updateSiteConfig(SiteConfig config) async {
@@ -498,7 +496,6 @@ class StorageService {
         _siteApiKeysCache[config.id] = config.apiKey; // 更新缓存
       }
     }
-    _siteConfigsCacheDirty = true; // 标记缓存失效
   }
 
   Future<void> deleteSiteConfig(String siteId) async {
@@ -517,7 +514,6 @@ class StorageService {
     if (activeSiteId == siteId) {
       await setActiveSiteId(null);
     }
-    _siteConfigsCacheDirty = true; // 标记缓存失效
   }
 
   Future<void> setActiveSiteId(String? siteId) async {

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pt_mate/services/storage/storage_service.dart';
+import 'package:pt_mate/models/app_models.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/services.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+
+    // Mock FlutterSecureStorage
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        return null;
+      },
+    );
+  });
+
+  test('StorageService caching optimization test (Add, Update, Delete)', () async {
+    final service = StorageService.instance;
+
+    // 1. Initial load (should be empty)
+    var configs = await service.loadSiteConfigs();
+    expect(configs, isEmpty);
+
+    // --- ADD TEST ---
+    final newConfig = SiteConfig(
+      id: 'test-site-1',
+      name: 'Test Site',
+      baseUrl: 'https://test.com',
+      apiKey: 'test-key',
+    );
+
+    await service.addSiteConfig(newConfig);
+
+    // Get the cache after add
+    final cacheAfterAdd = service.siteConfigsCache;
+    expect(cacheAfterAdd, isNotNull);
+    expect(cacheAfterAdd!.length, 1);
+    expect(cacheAfterAdd.first.id, 'test-site-1');
+
+    // Load site configs again
+    final loadedConfigsAfterAdd = await service.loadSiteConfigs();
+    // Verify instance identity (no re-decoding)
+    expect(loadedConfigsAfterAdd.first, same(cacheAfterAdd.first));
+
+
+    // --- UPDATE TEST ---
+    final updatedConfig = newConfig.copyWith(name: 'Updated Test Site');
+    await service.updateSiteConfig(updatedConfig);
+
+    final cacheAfterUpdate = service.siteConfigsCache;
+    expect(cacheAfterUpdate, isNotNull);
+    expect(cacheAfterUpdate!.length, 1);
+    expect(cacheAfterUpdate.first.name, 'Updated Test Site');
+
+    // Ensure the cache object is updated in place or replaced in list, but importantly,
+    // loadSiteConfigs should return the *current* cache content without re-decoding from disk.
+    final loadedConfigsAfterUpdate = await service.loadSiteConfigs();
+    expect(loadedConfigsAfterUpdate.first.name, 'Updated Test Site');
+    // Verify instance identity with the cache
+    expect(loadedConfigsAfterUpdate.first, same(cacheAfterUpdate.first));
+
+
+    // --- DELETE TEST ---
+    await service.deleteSiteConfig('test-site-1');
+
+    final cacheAfterDelete = service.siteConfigsCache;
+    expect(cacheAfterDelete, isNotNull);
+    expect(cacheAfterDelete!.isEmpty, isTrue);
+
+    final loadedConfigsAfterDelete = await service.loadSiteConfigs();
+    expect(loadedConfigsAfterDelete, isEmpty);
+    // Since list is empty, identity check on elements is N/A, but we can check if the list itself
+    // or the underlying mechanism didn't trigger a reload.
+    // Ideally we'd check logs or mock verify, but given the previous tests passed,
+    // ensuring correctness (empty list) is sufficient here.
+  });
+}


### PR DESCRIPTION
- Removed `_siteConfigsCacheDirty = true` from `addSiteConfig`, `updateSiteConfig`, and `deleteSiteConfig` in `lib/services/storage/storage_service.dart`.
- Added `test/storage_service_test.dart` to verify that `loadSiteConfigs` returns the exact same object instances after modifications, confirming the cache is being used.
- Verified that existing tests pass.

---
*PR created automatically by Jules for task [18114388028763197174](https://jules.google.com/task/18114388028763197174) started by @JustLookAtNow*