### PR TITLE
Refactor: Remove legacy `enabledSiteIds` from AggregateSearchConfig

### DIFF
--- a/lib/models/app_models.dart
+++ b/lib/models/app_models.dart
@@ -586,13 +586,6 @@ class AggregateSearchConfig {
           .map((item) => SiteSearchItem.fromJson(item as Map<String, dynamic>))
           .toList();
     }
-    // 兼容旧格式：enabledSiteIds TODO：删掉
-    else if (json['enabledSiteIds'] != null) {
-      enabledSites = (json['enabledSiteIds'] as List<dynamic>)
-          .cast<String>()
-          .map((id) => SiteSearchItem(id: id))
-          .toList();
-    }
 
     return AggregateSearchConfig(
       id:

--- a/test/models/app_models_test.dart
+++ b/test/models/app_models_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pt_mate/models/app_models.dart';
+
+void main() {
+  group('AggregateSearchConfig', () {
+    test('fromJson correctly parses new format (enabledSites)', () {
+      final json = {
+        'id': 'test-config',
+        'name': 'Test Config',
+        'type': 'custom',
+        'isActive': true,
+        'enabledSites': [
+          {'id': 'site1', 'additionalParams': null},
+          {'id': 'site2', 'additionalParams': {'key': 'value'}}
+        ]
+      };
+
+      final config = AggregateSearchConfig.fromJson(json);
+
+      expect(config.id, 'test-config');
+      expect(config.name, 'Test Config');
+      expect(config.type, 'custom');
+      expect(config.isActive, true);
+      expect(config.enabledSites.length, 2);
+      expect(config.enabledSites[0].id, 'site1');
+      expect(config.enabledSites[1].id, 'site2');
+      expect(config.enabledSites[1].additionalParams, {'key': 'value'});
+    });
+
+    test('fromJson ignores old format (enabledSiteIds)', () {
+      final json = {
+        'id': 'legacy-config',
+        'name': 'Legacy Config',
+        'type': 'custom',
+        'isActive': true,
+        'enabledSiteIds': ['site1', 'site2']
+      };
+
+      final config = AggregateSearchConfig.fromJson(json);
+
+      expect(config.id, 'legacy-config');
+      expect(config.name, 'Legacy Config');
+      // Should be empty since we removed the compatibility code
+      expect(config.enabledSites, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Removed the deprecated `enabledSiteIds` field support from `AggregateSearchConfig.fromJson` in `lib/models/app_models.dart`. This cleanup simplifies the codebase by removing legacy compatibility logic.

Added comprehensive unit tests in `test/models/app_models_test.dart` to ensure:
1. The new `enabledSites` format is parsed correctly.
2. The legacy `enabledSiteIds` format is now ignored (resulting in an empty list), confirming the removal of the compatibility code.

Verified that all relevant tests pass.

---
*PR created automatically by Jules for task [14772075179436211285](https://jules.google.com/task/14772075179436211285) started by @JustLookAtNow*