### PR TITLE
⚡ Bolt: Cache RegExp compilation in TagType.matchTags

### DIFF
--- a/lib/models/app_models.dart
+++ b/lib/models/app_models.dart
@@ -350,12 +350,21 @@ enum TagType {
   final Color color;
   final String regex;
 
+  static final Map<TagType, RegExp> _regexCache = {};
+
   // 从字符串中匹配所有标签
   static List<TagType> matchTags(String text) {
     List<TagType> matchedTags = [];
     for (TagType tag in TagType.values) {
       if (tag.regex.isEmpty) continue;
-      RegExp regExp = RegExp(tag.regex, caseSensitive: false);
+
+      // Lazily initialize and cache the RegExp object to prevent recompilation
+      // on hot paths like list rendering and parsing.
+      final regExp = _regexCache.putIfAbsent(
+        tag,
+        () => RegExp(tag.regex, caseSensitive: false),
+      );
+
       if (regExp.hasMatch(text)) {
         matchedTags.add(tag);
       }


### PR DESCRIPTION
💡 What: Introduced a static `_regexCache` inside the `TagType` enum to lazily initialize and cache `RegExp` objects when `TagType.matchTags` is called.
🎯 Why: The `TagType.matchTags` method is called frequently during torrent parsing (in multiple site adapters) and list rendering. Previously, it dynamically compiled a new `RegExp` for every tag enumeration that had a defined regex string, creating a significant and unnecessary CPU overhead.
📊 Impact: Eliminates redundant `RegExp` compilations during list and string parsing, reducing main thread workload and preventing frame drops on heavy list processing.
🔬 Measurement: Run the `test/models/app_models_test.dart` and `test/widgets/torrent_list_item_tags_test.dart` test suites, and observe reduced CPU time when parsing torrent descriptions in large lists.

---
*PR created automatically by Jules for task [8128921470658977689](https://jules.google.com/task/8128921470658977689) started by @JustLookAtNow*