### PR TITLE
🎨 Palette: Add Tooltips to interactive custom widgets

### DIFF
--- a/lib/widgets/qb_speed_indicator.dart
+++ b/lib/widgets/qb_speed_indicator.dart
@@ -169,48 +169,51 @@ class _QbSpeedIndicatorState extends State<QbSpeedIndicator> {
     }
     final info = _info!;
     final serverState = _serverState!;
-    return InkWell(
-      onTap: _openDownloader,
-      borderRadius: BorderRadius.circular(8),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.cloud_download,
-                  size: 16,
-                  color: Theme.of(context).brightness == Brightness.light
-                      ? Theme.of(context).colorScheme.onPrimary
-                      : Theme.of(context).colorScheme.onSurface,
-                ),
-                const SizedBox(width: 4),
-                Text(
-                  '↑${Formatters.speedFromBytesPerSec(info.upSpeed)} ↓${Formatters.speedFromBytesPerSec(info.dlSpeed)}',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+    return Tooltip(
+      message: '打开下载器',
+      child: InkWell(
+        onTap: _openDownloader,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.cloud_download,
+                    size: 16,
                     color: Theme.of(context).brightness == Brightness.light
                         ? Theme.of(context).colorScheme.onPrimary
                         : Theme.of(context).colorScheme.onSurface,
                   ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 2),
-            Text(
-              '剩余空间: ${Formatters.dataFromBytes(serverState.freeSpaceOnDisk)}',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color:
-                    (Theme.of(context).brightness == Brightness.light
-                            ? Theme.of(context).colorScheme.onPrimary
-                            : Theme.of(context).colorScheme.onSurface)
-                        .withValues(alpha: 0.8),
+                  const SizedBox(width: 4),
+                  Text(
+                    '↑${Formatters.speedFromBytesPerSec(info.upSpeed)} ↓${Formatters.speedFromBytesPerSec(info.dlSpeed)}',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).brightness == Brightness.light
+                          ? Theme.of(context).colorScheme.onPrimary
+                          : Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
+              const SizedBox(height: 2),
+              Text(
+                '剩余空间: ${Formatters.dataFromBytes(serverState.freeSpaceOnDisk)}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color:
+                      (Theme.of(context).brightness == Brightness.light
+                              ? Theme.of(context).colorScheme.onPrimary
+                              : Theme.of(context).colorScheme.onSurface)
+                          .withValues(alpha: 0.8),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/torrent_list_item.dart
+++ b/lib/widgets/torrent_list_item.dart
@@ -1151,25 +1151,28 @@ class _TagsViewState extends State<_TagsView> {
             ),
             if (_overflow && !ScreenUtils.isLargeScreen(context)) ...[
               const SizedBox(width: 8),
-              GestureDetector(
-                onTap: () {
-                  setState(() {
-                    _expanded = true;
-                  });
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 1,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.primary,
-                    borderRadius: BorderRadius.circular(3),
-                  ),
-                  child: const Icon(
-                    Icons.keyboard_arrow_down,
-                    size: 12,
-                    color: Colors.white,
+              Tooltip(
+                message: '展开标签',
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _expanded = true;
+                    });
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.primary,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: const Icon(
+                      Icons.keyboard_arrow_down,
+                      size: 12,
+                      color: Colors.white,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
💡 What: Added `Tooltip` wrappers to two custom icon-only interactive widgets (`QbSpeedIndicator` and `TorrentListItem` tag expander).
🎯 Why: Standard `IconButton`s support tooltips out of the box, but custom interactive elements made with `InkWell` or `GestureDetector` that display only icons lack accessibility labels. This causes screen readers to announce an unlabeled button, and desktop/web users lack a hover hint to know what the button does.
♿ Accessibility: Adds semantic labels to custom interactive areas, benefiting both screen reader and mouse users.

---
*PR created automatically by Jules for task [16225811034036547602](https://jules.google.com/task/16225811034036547602) started by @JustLookAtNow*