### PR TITLE
🎨 Palette: Add Tooltip to expand tags button in TorrentListItem

### DIFF
--- a/lib/widgets/torrent_list_item.dart
+++ b/lib/widgets/torrent_list_item.dart
@@ -1151,25 +1151,28 @@ class _TagsViewState extends State<_TagsView> {
             ),
             if (_overflow && !ScreenUtils.isLargeScreen(context)) ...[
               const SizedBox(width: 8),
-              GestureDetector(
-                onTap: () {
-                  setState(() {
-                    _expanded = true;
-                  });
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 1,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.primary,
-                    borderRadius: BorderRadius.circular(3),
-                  ),
-                  child: const Icon(
-                    Icons.keyboard_arrow_down,
-                    size: 12,
-                    color: Colors.white,
+              Tooltip(
+                message: '展开标签',
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _expanded = true;
+                    });
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.primary,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: const Icon(
+                      Icons.keyboard_arrow_down,
+                      size: 12,
+                      color: Colors.white,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
**What**: Added a `Tooltip` wrapper around the `GestureDetector` that contains the `keyboard_arrow_down` icon in `lib/widgets/torrent_list_item.dart`.

**Why**: This button is an icon-only interactive widget used to expand overflowing tags. Without a tooltip, it lacks hover feedback on desktop/web environments and is inaccessible to screen readers, missing semantic labeling. Adding a tooltip ensures better accessibility (a11y) and a more intuitive micro-UX.

**Accessibility**: Screen readers will now announce "展开标签" (Expand tags) when focusing on this interactive element. Hovering with a mouse will display the same text.

---
*PR created automatically by Jules for task [6425577342618043085](https://jules.google.com/task/6425577342618043085) started by @JustLookAtNow*