### PR TITLE
🎨 Palette: [UX improvement] Add tooltips to custom icon-only interactive widgets

### DIFF
--- a/lib/pages/server_settings_page.dart
+++ b/lib/pages/server_settings_page.dart
@@ -2093,7 +2093,9 @@ class _SiteEditPageState extends State<SiteEditPage> {
 
     try {
       final tempSite = _composeCurrentSite();
-      final adapter = await ApiService.instance.createTemporaryAdapter(tempSite);
+      final adapter = await ApiService.instance.createTemporaryAdapter(
+        tempSite,
+      );
 
       final categories = await adapter.getSearchCategories();
       setState(() {
@@ -2722,30 +2724,33 @@ class _SiteEditPageState extends State<SiteEditPage> {
                   children: [
                     Text('站点颜色', style: Theme.of(context).textTheme.bodyMedium),
                     const SizedBox(width: 12),
-                    GestureDetector(
-                      onTap: () async {
-                        final picked = await showDialog<Color>(
-                          context: context,
-                          builder: (context) => _SiteColorPickerDialog(
-                            initialColor:
+                    Tooltip(
+                      message: '选择站点颜色',
+                      child: GestureDetector(
+                        onTap: () async {
+                          final picked = await showDialog<Color>(
+                            context: context,
+                            builder: (context) => _SiteColorPickerDialog(
+                              initialColor:
+                                  _siteColor ??
+                                  Theme.of(context).colorScheme.primary,
+                            ),
+                          );
+                          if (picked != null) {
+                            setState(() => _siteColor = picked);
+                          }
+                        },
+                        child: Container(
+                          width: 32,
+                          height: 32,
+                          decoration: BoxDecoration(
+                            color:
                                 _siteColor ??
                                 Theme.of(context).colorScheme.primary,
-                          ),
-                        );
-                        if (picked != null) {
-                          setState(() => _siteColor = picked);
-                        }
-                      },
-                      child: Container(
-                        width: 32,
-                        height: 32,
-                        decoration: BoxDecoration(
-                          color:
-                              _siteColor ??
-                              Theme.of(context).colorScheme.primary,
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: Theme.of(context).colorScheme.outline,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: Theme.of(context).colorScheme.outline,
+                            ),
                           ),
                         ),
                       ),

--- a/lib/widgets/torrent_list_item.dart
+++ b/lib/widgets/torrent_list_item.dart
@@ -1151,25 +1151,28 @@ class _TagsViewState extends State<_TagsView> {
             ),
             if (_overflow && !ScreenUtils.isLargeScreen(context)) ...[
               const SizedBox(width: 8),
-              GestureDetector(
-                onTap: () {
-                  setState(() {
-                    _expanded = true;
-                  });
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 1,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.primary,
-                    borderRadius: BorderRadius.circular(3),
-                  ),
-                  child: const Icon(
-                    Icons.keyboard_arrow_down,
-                    size: 12,
-                    color: Colors.white,
+              Tooltip(
+                message: '展开标签',
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _expanded = true;
+                    });
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.primary,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                    child: const Icon(
+                      Icons.keyboard_arrow_down,
+                      size: 12,
+                      color: Colors.white,
+                    ),
                   ),
                 ),
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -649,18 +649,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1022,10 +1022,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
### 💡 What:
Added `Tooltip` wrappers to custom icon-only interactive components that use `GestureDetector`. Specifically:
1. The "expand tags" down-arrow button in `lib/widgets/torrent_list_item.dart`.
2. The site color picker circle in `lib/pages/server_settings_page.dart`.

### 🎯 Why:
While standard `IconButton` widgets accept a `tooltip` property, custom interactive icons built using `GestureDetector` or `InkWell` do not. This leaves these elements completely inaccessible to screen readers and prevents helpful hover text from displaying on desktop and web environments.

### ♿ Accessibility:
- Screen readers will now correctly announce "展开标签" (Expand tags) and "选择站点颜色" (Select site color) instead of silence or a generic "button" label.
- Mouse and hover interactions on desktop/web will now present descriptive text, aiding discoverability.

---
*PR created automatically by Jules for task [16915671100134482092](https://jules.google.com/task/16915671100134482092) started by @JustLookAtNow*