### PR TITLE
🎨 Palette: Add tooltips to icon-only PopupMenuButtons

### DIFF
--- a/lib/pages/download_tasks_page.dart
+++ b/lib/pages/download_tasks_page.dart
@@ -744,7 +744,6 @@ class _DownloadTasksPageState extends State<DownloadTasksPage> {
                   tooltip: isPaused ? '恢复' : '暂停',
                   constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
                   padding: EdgeInsets.zero,
-                  tooltip: isPaused ? '继续' : '暂停',
                   onPressed: () => isPaused ? _resumeTask(task.hash) : _pauseTask(task.hash),
                 ),
                 IconButton(
@@ -752,7 +751,6 @@ class _DownloadTasksPageState extends State<DownloadTasksPage> {
                   tooltip: '删除',
                   constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
                   padding: EdgeInsets.zero,
-                  tooltip: '删除',
                   onPressed: () => _confirmDelete(task),
                 ),
               ],


### PR DESCRIPTION
💡 **What**: Added `tooltip: '选项'` to `PopupMenuButton` widgets in the server settings page and aggregate search settings page. Cleaned up duplicate tooltip attributes in download tasks page.
🎯 **Why**: Icon-only menus (like `PopupMenuButton`) lack semantic meaning for screen readers and don't show hover feedback on desktop platforms unless a `tooltip` string is explicitly provided. This improves overall keyboard accessibility and UI discoverability.
📸 **Before/After**: Visually unchanged on mobile unless long-pressed; on desktop/web, hovering over the context menu icons now displays "选项" (Options) instead of nothing.
♿ **Accessibility**: Provides necessary ARIA-equivalent labels to screen readers for critical settings actions.

---
*PR created automatically by Jules for task [1205530211742918021](https://jules.google.com/task/1205530211742918021) started by @JustLookAtNow*