### PR TITLE
fix: ruTorrent 302 error when adding a torrent and fix list order

### DIFF
--- a/lib/services/downloader/rutorrent_client.dart
+++ b/lib/services/downloader/rutorrent_client.dart
@@ -19,6 +19,12 @@ class RuTorrentClient
   final RuTorrentConfig config;
   final String password;
 
+  /// ruTorrent官方的base64负载上限（php/rtorrent.php RTORRENT_PACKET_LIMIT）
+  /// base64编码后达到该长度时，load.raw会超出rTorrent的XML-RPC包大小限制；
+  /// 官方此时改为写服务器临时文件再按路径加载，该回退依赖服务器文件系统，
+  /// 客户端只能改走 /php/addtorrent.php 上传由服务端处理
+  static const int rtorrentPacketLimit = 1572864;
+
   // HTTP客户端
   late final Dio _dio;
 
@@ -32,7 +38,12 @@ class RuTorrentClient
     required this.config,
     required this.password,
     Function(RuTorrentConfig)? onConfigUpdated,
+    Dio? dio, // 供测试注入
   }) : _onConfigUpdated = onConfigUpdated {
+    if (dio != null) {
+      _dio = dio;
+      return;
+    }
     _dio = Dio(
       BaseOptions(
         connectTimeout: const Duration(seconds: 10),
@@ -90,12 +101,15 @@ class RuTorrentClient
   }
 
   /// 执行HTTP请求
+  /// [acceptRedirect] 为true时不跟随重定向，且3xx不视为错误
+  /// （addtorrent.php以302的Location参数返回结果）
   Future<Response> _request(
     String method,
     String endpoint, {
     Map<String, String>? headers,
     dynamic body,
     bool useAuth = true,
+    bool acceptRedirect = false,
   }) async {
     final url = '$_baseUrl$endpoint';
 
@@ -134,6 +148,10 @@ class RuTorrentClient
             options: Options(
               headers: requestHeaders,
               contentType: requestHeaders['Content-Type'],
+              followRedirects: acceptRedirect ? false : null,
+              validateStatus: acceptRedirect
+                  ? (status) => status != null && status < 400
+                  : null,
             ),
           );
           break;
@@ -268,6 +286,66 @@ class RuTorrentClient
     return builder.buildDocument().toXmlString();
   }
 
+  /// 构建单个方法调用的XML-RPC请求
+  /// 参数支持字符串和二进制数据（List&lt;int&gt;，编码为base64）
+  String _buildMethodCallXML(String method, List<dynamic> params) {
+    final builder = XmlBuilder();
+    builder.processing('xml', 'version="1.0" encoding="UTF-8"');
+    builder.element(
+      'methodCall',
+      nest: () {
+        builder.element('methodName', nest: method);
+        builder.element(
+          'params',
+          nest: () {
+            for (final param in params) {
+              builder.element(
+                'param',
+                nest: () {
+                  builder.element(
+                    'value',
+                    nest: () {
+                      if (param is List<int>) {
+                        builder.element('base64', nest: base64Encode(param));
+                      } else {
+                        builder.element('string', nest: param.toString());
+                      }
+                    },
+                  );
+                },
+              );
+            }
+          },
+        );
+      },
+    );
+
+    return builder.buildDocument().toXmlString();
+  }
+
+  /// 检查XML-RPC响应中的fault，出错时抛出异常
+  void _checkXmlRpcFault(String xmlString) {
+    final XmlDocument document;
+    try {
+      document = XmlDocument.parse(xmlString);
+    } catch (_) {
+      // 响应不是合法XML（如网关返回的HTML错误页），不在此处判定失败
+      return;
+    }
+    if (document.findAllElements('fault').isNotEmpty) {
+      String message = 'Unknown XML-RPC fault';
+      for (final member in document.findAllElements('member')) {
+        final name = member.getElement('name')?.innerText;
+        if (name == 'faultString') {
+          message =
+              member.getElement('value')?.innerText.trim() ?? message;
+          break;
+        }
+      }
+      throw Exception('XML-RPC fault: $message');
+    }
+  }
+
   /// 解析XML-RPC响应
   List<String> _parseResponseXML(String xmlString) {
     final document = XmlDocument.parse(xmlString);
@@ -290,8 +368,6 @@ class RuTorrentClient
   int _iv(String? val) {
     return FormatUtil.parseInt(val) ?? 0;
   }
-
-
 
   @override
   Future<void> testConnection() async {
@@ -457,16 +533,80 @@ class RuTorrentClient
     final Map<String, dynamic> torrents =
         data['t'] as Map<String, dynamic>? ?? {};
 
+    // 列表接口不包含添加/完成时间，需单独从custom字段获取
+    final timeCustoms = await _fetchTimeCustoms();
+
     final tasks = <DownloadTask>[];
 
     for (final entry in torrents.entries) {
       final hash = entry.key;
       final torrentData = entry.value as List<dynamic>;
+      final times = timeCustoms[hash.toUpperCase()];
 
-      tasks.add(_convertToDownloadTask(hash, torrentData));
+      tasks.add(
+        _convertToDownloadTask(
+          hash,
+          torrentData,
+          addTime: times?.$1 ?? 0,
+          completedTime: times?.$2 ?? 0,
+        ),
+      );
     }
 
     return tasks;
+  }
+
+  /// 获取所有种子的添加时间与完成时间
+  /// ruTorrent将其存储在custom字段addtime/seedingtime中，mode=list不返回
+  /// 返回 hash(大写) -> (addtime, seedingtime)，字段未设置时为0
+  Future<Map<String, (int, int)>> _fetchTimeCustoms() async {
+    try {
+      final xml = _buildMethodCallXML('d.multicall2', [
+        '',
+        'main',
+        'd.hash=',
+        'd.custom=addtime',
+        'd.custom=seedingtime',
+      ]);
+
+      final response = await _request(
+        'POST',
+        '/plugins/httprpc/action.php',
+        headers: {'Content-Type': 'application/xml'},
+        body: xml,
+      );
+
+      final document = XmlDocument.parse(response.data.toString());
+      final result = <String, (int, int)>{};
+
+      final dataElements = document.findAllElements('data');
+      if (dataElements.isEmpty) return result;
+
+      // 外层data的每个value对应一个种子：[hash, addtime, seedingtime]
+      for (final value in dataElements.first.childElements.where(
+        (e) => e.name.local == 'value',
+      )) {
+        final strings = value.findAllElements('string').toList();
+        if (strings.isEmpty) continue;
+
+        final hash = strings[0].innerText.trim();
+        final addTime = strings.length > 1
+            ? (int.tryParse(strings[1].innerText.trim()) ?? 0)
+            : 0;
+        final completedTime = strings.length > 2
+            ? (int.tryParse(strings[2].innerText.trim()) ?? 0)
+            : 0;
+
+        if (hash.isNotEmpty) {
+          result[hash.toUpperCase()] = (addTime, completedTime);
+        }
+      }
+
+      return result;
+    } catch (_) {
+      // 获取失败时不影响任务列表本身
+      return {};
+    }
   }
 
   @override
@@ -480,50 +620,154 @@ class RuTorrentClient
 
     final useRelay = config.useLocalRelay || forceRelay;
 
+    final savePath = params.savePath?.trim() ?? '';
+    if (savePath.isNotEmpty) {
+      _validateSavePath(savePath);
+    }
+
+    // 附加命令：记录添加时间（ruTorrent约定的custom字段）、保存路径与标签
+    // label需URL编码，与ruTorrent存储格式一致
+    final commands = <String>[
+      'd.custom.set=addtime,${DateTime.now().millisecondsSinceEpoch ~/ 1000}',
+    ];
+    if (savePath.isNotEmpty) {
+      commands.add('d.directory.set="$savePath"');
+    }
+    if (params.category != null && params.category!.isNotEmpty) {
+      commands.add('d.custom1.set=${Uri.encodeComponent(params.category!)}');
+    }
+
+    final startPaused = params.startPaused == true;
+
+    String xml;
     if (url.startsWith('magnet:') && !useRelay) {
-      // Magnet链接，使用URLSearchParams
-      final body = <String, dynamic>{'url': url, 'json': '1'};
-
-      if (params.savePath != null) {
-        body['dir_edit'] = params.savePath;
-      }
-      if (params.startPaused == true) {
-        body['torrents_start_stopped'] = '1';
-      }
-      if (params.category != null && params.category!.isNotEmpty) {
-        body['label'] = params.category;
-      }
-
-      final formData = FormData.fromMap(body);
-      await _request('POST', '/php/addtorrent.php', body: formData);
+      // Magnet链接：由rTorrent直接加载
+      final method = startPaused ? 'load.normal' : 'load.start';
+      xml = _buildMethodCallXML(method, ['', url, ...commands]);
     } else {
-      // 种子文件，需要先下载
+      // 种子文件：先下载到本地
       final torrentData = await downloadTorrentFileCommon(
         _dio,
         url,
         siteConfig: siteConfig,
       );
 
-      final body = <String, dynamic>{
-        'torrent_file': MultipartFile.fromBytes(
-          torrentData,
-          filename: 'ptmate.torrent',
-        ),
-        'json': '1',
-      };
-
-      if (params.savePath != null) {
-        body['dir_edit'] = params.savePath;
-      }
-      if (params.startPaused == true) {
-        body['torrents_start_stopped'] = '1';
-      }
-      if (params.category != null && params.category!.isNotEmpty) {
-        body['label'] = params.category;
+      // 与ruTorrent官方相同的判断：base64编码后达到包大小上限的种子
+      // 无法经load.raw提交，改走addtorrent.php由服务端落盘后加载
+      final base64Length = ((torrentData.length + 2) ~/ 3) * 4;
+      if (base64Length >= rtorrentPacketLimit) {
+        await _addTorrentFileViaWeb(torrentData, params);
+        return;
       }
 
-      final formData = FormData.fromMap(body);
-      await _request('POST', '/php/addtorrent.php', body: formData);
+      final method = startPaused ? 'load.raw' : 'load.raw_start';
+      xml = _buildMethodCallXML(method, ['', torrentData, ...commands]);
+    }
+
+    // 官方sendTorrent/sendMagnet设置保存路径前会先在服务端execute mkdir -p，
+    // 避免目录不存在时rTorrent开始写入才失败；~与相对路径由服务端配置解析，
+    // 客户端无法复刻，仅对绝对路径创建
+    if (savePath.startsWith('/')) {
+      await _ensureRemoteDirectory(savePath);
+    }
+
+    final response = await _request(
+      'POST',
+      '/plugins/httprpc/action.php',
+      headers: {'Content-Type': 'application/xml'},
+      body: xml,
+    );
+
+    _checkXmlRpcFault(response.data.toString());
+  }
+
+  /// 校验保存路径，对应官方addtorrent.php经correctDirectory()的拒绝行为
+  /// 官方基于服务器配置解析路径归属，客户端无法复刻，
+  /// 此处拦截会破坏rTorrent命令引用的非法字符
+  void _validateSavePath(String path) {
+    if (path.contains('"') || path.codeUnits.any((c) => c < 0x20)) {
+      throw Exception('ruTorrent: invalid save path (FailedDirectory)');
+    }
+  }
+
+  /// 在服务端创建保存目录，等价于官方sendTorrent中的execute mkdir -p
+  /// （官方经方法表把execute映射为execute2并前置空target，
+  /// execute2在rTorrent 0.9.4至当前master均可用）
+  /// 官方multicall中mkdir失败不阻断load，此处保持一致
+  Future<void> _ensureRemoteDirectory(String directory) async {
+    try {
+      final xml = _buildMethodCallXML('execute2', [
+        '',
+        'mkdir',
+        '-p',
+        directory,
+      ]);
+      await _request(
+        'POST',
+        '/plugins/httprpc/action.php',
+        headers: {'Content-Type': 'application/xml'},
+        body: xml,
+      );
+    } catch (_) {
+      // 目录创建失败不阻断添加，写入问题由rTorrent自身报告
+    }
+  }
+
+  /// 通过 /php/addtorrent.php 以multipart上传种子文件（大文件专用）
+  /// addtime由ruTorrent的seedingtime插件注册的inserted_new事件自动写入，
+  /// 无需在此设置
+  Future<void> _addTorrentFileViaWeb(
+    List<int> torrentData,
+    AddTaskParams params,
+  ) async {
+    final form = <String, dynamic>{
+      'torrent_file': MultipartFile.fromBytes(
+        torrentData,
+        filename: 'pt_mate.torrent',
+      ),
+      'json': '1',
+    };
+    if (params.savePath != null && params.savePath!.isNotEmpty) {
+      form['dir_edit'] = params.savePath!;
+    }
+    if (params.category != null && params.category!.isNotEmpty) {
+      // 服务端会自行URL编码后存入custom1
+      form['label'] = params.category!;
+    }
+    if (params.startPaused == true) {
+      form['torrents_start_stopped'] = '1';
+    }
+
+    final response = await _request(
+      'POST',
+      '/php/addtorrent.php',
+      body: FormData.fromMap(form),
+      acceptRedirect: true,
+    );
+
+    final result = _parseAddTorrentResult(response);
+    if (result != 'Success') {
+      throw Exception(
+        'ruTorrent addtorrent.php failed: '
+        '${result ?? 'unexpected response (HTTP ${response.statusCode})'}',
+      );
+    }
+  }
+
+  /// 解析addtorrent.php的结果
+  /// 正常返回302，结果在Location头的result[]参数中；
+  /// 若反向代理等中间层已跟随重定向，则按JSON响应解析
+  String? _parseAddTorrentResult(Response response) {
+    if (response.statusCode == 302) {
+      final location = response.headers.value('location') ?? '';
+      return RegExp(r'result\[\]=(\w+)').firstMatch(location)?.group(1);
+    }
+    try {
+      final data = response.data;
+      final map = data is Map ? data : jsonDecode(data.toString());
+      return map['result']?.toString();
+    } catch (_) {
+      return null;
     }
   }
 
@@ -646,10 +890,13 @@ class RuTorrentClient
   }
 
   /// 将ruTorrent API响应转换为DownloadTask
+  /// [addTime]/[completedTime] 来自custom字段，未设置时为0
   DownloadTask _convertToDownloadTask(
     String infoHash,
-    List<dynamic> rawTorrent,
-  ) {
+    List<dynamic> rawTorrent, {
+    int addTime = 0,
+    int completedTime = 0,
+  }) {
     // 解析各字段
     final isOpen = _iv(rawTorrent[0].toString());
     final isHashChecking = _iv(rawTorrent[1].toString());
@@ -719,9 +966,10 @@ class RuTorrentClient
       eta: 0, // ruTorrent API 中没有直接的 ETA 字段
       category: torrentLabel,
       tags: torrentLabel.isNotEmpty ? [torrentLabel] : [],
-      completionOn: 0,
+      completionOn: completedTime,
       contentPath: savePath,
-      addedOn: created,
+      // addtime未设置时回退到种子文件创建时间
+      addedOn: addTime > 0 ? addTime : created,
       amountLeft: torrentSize - torrentDownloaded,
       ratio: ratio / 1000.0, // 转换为实际比率
       timeActive: 0,

--- a/lib/services/downloader/rutorrent_client.dart
+++ b/lib/services/downloader/rutorrent_client.dart
@@ -337,8 +337,7 @@ class RuTorrentClient
       for (final member in document.findAllElements('member')) {
         final name = member.getElement('name')?.innerText;
         if (name == 'faultString') {
-          message =
-              member.getElement('value')?.innerText.trim() ?? message;
+          message = member.getElement('value')?.innerText.trim() ?? message;
           break;
         }
       }
@@ -621,26 +620,35 @@ class RuTorrentClient
     final useRelay = config.useLocalRelay || forceRelay;
 
     final savePath = params.savePath?.trim() ?? '';
-    if (savePath.isNotEmpty) {
-      _validateSavePath(savePath);
-    }
 
-    // 附加命令：记录添加时间（ruTorrent约定的custom字段）、保存路径与标签
+    // 附加命令：记录添加时间（ruTorrent约定的custom字段）与标签
     // label需URL编码，与ruTorrent存储格式一致
-    final commands = <String>[
-      'd.custom.set=addtime,${DateTime.now().millisecondsSinceEpoch ~/ 1000}',
-    ];
-    if (savePath.isNotEmpty) {
-      commands.add('d.directory.set="$savePath"');
-    }
+    final addTimeCommand =
+        'd.custom.set=addtime,'
+        '${DateTime.now().millisecondsSinceEpoch ~/ 1000}';
+    final commands = <String>[addTimeCommand];
     if (params.category != null && params.category!.isNotEmpty) {
       commands.add('d.custom1.set=${Uri.encodeComponent(params.category!)}');
     }
 
     final startPaused = params.startPaused == true;
+    final directMagnet = url.startsWith('magnet:') && !useRelay;
+
+    // ruTorrent只有在服务端可信连接中才能执行目录校验与mkdir -p。
+    // 带保存路径的任务统一交给addtorrent.php处理，避免raw XML-RPC代理
+    // 将execute2作为不可信命令拒绝。
+    if (directMagnet && savePath.isNotEmpty) {
+      await _addMagnetViaWeb(
+        url,
+        params,
+        savePath: savePath,
+        addTimeCommand: addTimeCommand,
+      );
+      return;
+    }
 
     String xml;
-    if (url.startsWith('magnet:') && !useRelay) {
+    if (directMagnet) {
       // Magnet链接：由rTorrent直接加载
       final method = startPaused ? 'load.normal' : 'load.start';
       xml = _buildMethodCallXML(method, ['', url, ...commands]);
@@ -655,20 +663,18 @@ class RuTorrentClient
       // 与ruTorrent官方相同的判断：base64编码后达到包大小上限的种子
       // 无法经load.raw提交，改走addtorrent.php由服务端落盘后加载
       final base64Length = ((torrentData.length + 2) ~/ 3) * 4;
-      if (base64Length >= rtorrentPacketLimit) {
-        await _addTorrentFileViaWeb(torrentData, params);
+      if (savePath.isNotEmpty || base64Length >= rtorrentPacketLimit) {
+        await _addTorrentFileViaWeb(
+          torrentData,
+          params,
+          savePath: savePath,
+          addTimeCommand: addTimeCommand,
+        );
         return;
       }
 
       final method = startPaused ? 'load.raw' : 'load.raw_start';
       xml = _buildMethodCallXML(method, ['', torrentData, ...commands]);
-    }
-
-    // 官方sendTorrent/sendMagnet设置保存路径前会先在服务端execute mkdir -p，
-    // 避免目录不存在时rTorrent开始写入才失败；~与相对路径由服务端配置解析，
-    // 客户端无法复刻，仅对绝对路径创建
-    if (savePath.startsWith('/')) {
-      await _ensureRemoteDirectory(savePath);
     }
 
     final response = await _request(
@@ -681,45 +687,30 @@ class RuTorrentClient
     _checkXmlRpcFault(response.data.toString());
   }
 
-  /// 校验保存路径，对应官方addtorrent.php经correctDirectory()的拒绝行为
-  /// 官方基于服务器配置解析路径归属，客户端无法复刻，
-  /// 此处拦截会破坏rTorrent命令引用的非法字符
-  void _validateSavePath(String path) {
-    if (path.contains('"') || path.codeUnits.any((c) => c < 0x20)) {
-      throw Exception('ruTorrent: invalid save path (FailedDirectory)');
-    }
+  /// 通过 /php/addtorrent.php 添加Magnet，由服务端校验并创建保存目录
+  Future<void> _addMagnetViaWeb(
+    String magnet,
+    AddTaskParams params, {
+    required String savePath,
+    required String addTimeCommand,
+  }) async {
+    final form = <String, dynamic>{'url': magnet, 'json': '1'};
+    _addWebTaskOptions(
+      form,
+      params,
+      savePath: savePath,
+      addTimeCommand: addTimeCommand,
+    );
+    await _submitAddTorrentForm(form);
   }
 
-  /// 在服务端创建保存目录，等价于官方sendTorrent中的execute mkdir -p
-  /// （官方经方法表把execute映射为execute2并前置空target，
-  /// execute2在rTorrent 0.9.4至当前master均可用）
-  /// 官方multicall中mkdir失败不阻断load，此处保持一致
-  Future<void> _ensureRemoteDirectory(String directory) async {
-    try {
-      final xml = _buildMethodCallXML('execute2', [
-        '',
-        'mkdir',
-        '-p',
-        directory,
-      ]);
-      await _request(
-        'POST',
-        '/plugins/httprpc/action.php',
-        headers: {'Content-Type': 'application/xml'},
-        body: xml,
-      );
-    } catch (_) {
-      // 目录创建失败不阻断添加，写入问题由rTorrent自身报告
-    }
-  }
-
-  /// 通过 /php/addtorrent.php 以multipart上传种子文件（大文件专用）
-  /// addtime由ruTorrent的seedingtime插件注册的inserted_new事件自动写入，
-  /// 无需在此设置
+  /// 通过 /php/addtorrent.php 以multipart上传种子文件
   Future<void> _addTorrentFileViaWeb(
     List<int> torrentData,
-    AddTaskParams params,
-  ) async {
+    AddTaskParams params, {
+    required String savePath,
+    required String addTimeCommand,
+  }) async {
     final form = <String, dynamic>{
       'torrent_file': MultipartFile.fromBytes(
         torrentData,
@@ -727,8 +718,24 @@ class RuTorrentClient
       ),
       'json': '1',
     };
-    if (params.savePath != null && params.savePath!.isNotEmpty) {
-      form['dir_edit'] = params.savePath!;
+    _addWebTaskOptions(
+      form,
+      params,
+      savePath: savePath,
+      addTimeCommand: addTimeCommand,
+    );
+    await _submitAddTorrentForm(form);
+  }
+
+  /// 填充addtorrent.php通用参数
+  void _addWebTaskOptions(
+    Map<String, dynamic> form,
+    AddTaskParams params, {
+    required String savePath,
+    required String addTimeCommand,
+  }) {
+    if (savePath.isNotEmpty) {
+      form['dir_edit'] = savePath;
     }
     if (params.category != null && params.category!.isNotEmpty) {
       // 服务端会自行URL编码后存入custom1
@@ -738,6 +745,11 @@ class RuTorrentClient
       form['torrents_start_stopped'] = '1';
     }
 
+    // 即使未启用seedingtime插件，也保留真实添加时间用于列表排序。
+    form['addition[]'] = addTimeCommand;
+  }
+
+  Future<void> _submitAddTorrentForm(Map<String, dynamic> form) async {
     final response = await _request(
       'POST',
       '/php/addtorrent.php',

--- a/test/services/downloader/rutorrent_client_test.dart
+++ b/test/services/downloader/rutorrent_client_test.dart
@@ -1,0 +1,607 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pt_mate/services/downloader/downloader_config.dart';
+import 'package:pt_mate/services/downloader/downloader_models.dart';
+import 'package:pt_mate/services/downloader/rutorrent_client.dart';
+
+/// 构造 mode=list 返回的种子数组（索引与 httprpc 插件一致，共30项）
+List<String> buildRawTorrent({
+  String isOpen = '1',
+  String isHashChecking = '0',
+  String getState = '1',
+  String name = 'Test.Torrent',
+  String size = '2000',
+  String completedChunks = '50',
+  String sizeChunks = '100',
+  String downloaded = '1000',
+  String uploaded = '500',
+  String ratio = '500',
+  String upSpeed = '10',
+  String dlSpeed = '20',
+  String label = '',
+  String hashing = '0',
+  String hashedChunks = '0',
+  String basePath = '/downloads/Test.Torrent',
+  String created = '1600000000',
+  String isActive = '1',
+  String message = '',
+}) {
+  return [
+    isOpen, // 0 is_open
+    isHashChecking, // 1 is_hash_checking
+    '1', // 2 is_hash_checked
+    getState, // 3 state
+    name, // 4 name
+    size, // 5 size_bytes
+    completedChunks, // 6 completed_chunks
+    sizeChunks, // 7 size_chunks
+    downloaded, // 8 bytes_done
+    uploaded, // 9 up.total
+    ratio, // 10 ratio
+    upSpeed, // 11 up.rate
+    dlSpeed, // 12 down.rate
+    '1024', // 13 chunk_size
+    label, // 14 custom1
+    '0', // 15 peers_accounted
+    '0', // 16 peers_not_connected
+    '0', // 17 peers_connected
+    '0', // 18 peers_complete
+    '0', // 19 left_bytes
+    '0', // 20 priority
+    '0', // 21 state_changed
+    '0', // 22 skip.total
+    hashing, // 23 hashing
+    hashedChunks, // 24 chunks_hashed
+    basePath, // 25 base_path
+    created, // 26 creation_date
+    '', // 27 tracker_focus
+    isActive, // 28 is_active
+    message, // 29 message
+  ];
+}
+
+class _FakeHttpClientAdapter implements HttpClientAdapter {
+  /// mode=list 返回的种子表
+  Map<String, List<String>> torrents = {};
+
+  /// hash(大写) -> [addtime, seedingtime]
+  Map<String, List<String>> timeCustoms = {};
+
+  /// 记录发往 httprpc 的 XML-RPC 请求体
+  final List<String> xmlRequests = [];
+
+  /// 模拟 custom 字段查询失败
+  bool failTimeCustoms = false;
+
+  /// load 命令返回 fault
+  bool faultOnLoad = false;
+
+  /// 种子文件下载内容
+  List<int> torrentFileBytes = [1, 2, 3, 4];
+
+  /// 记录发往 addtorrent.php 的multipart请求体
+  final List<String> uploadRequests = [];
+
+  /// 记录 execute2 mkdir 请求体
+  final List<String> mkdirRequests = [];
+
+  /// mkdir 命令返回 fault
+  bool failMkdir = false;
+
+  /// addtorrent.php 通过302 Location返回的result[]值
+  String addTorrentResult = 'Success';
+
+  /// 模拟中间层已跟随重定向：addtorrent.php 直接返回200+JSON
+  bool addTorrentRespondJson = false;
+
+  Future<String> _readBody(Stream<Uint8List>? stream) async {
+    if (stream == null) return '';
+    final bytes = <int>[];
+    await for (final chunk in stream) {
+      bytes.addAll(chunk);
+    }
+    return utf8.decode(bytes);
+  }
+
+  String _multicallResponse() {
+    final rows = timeCustoms.entries
+        .map(
+          (e) =>
+              '<value><array><data>'
+              '<value><string>${e.key}</string></value>'
+              '<value><string>${e.value[0]}</string></value>'
+              '<value><string>${e.value[1]}</string></value>'
+              '</data></array></value>',
+        )
+        .join();
+    return '<?xml version="1.0" encoding="UTF-8"?>'
+        '<methodResponse><params><param><value><array><data>'
+        '$rows'
+        '</data></array></value></param></params></methodResponse>';
+  }
+
+  static const _successResponse =
+      '<?xml version="1.0" encoding="UTF-8"?>'
+      '<methodResponse><params><param><value><i4>0</i4></value></param>'
+      '</params></methodResponse>';
+
+  static const _faultResponse =
+      '<?xml version="1.0" encoding="UTF-8"?>'
+      '<methodResponse><fault><value><struct>'
+      '<member><name>faultCode</name><value><i4>-501</i4></value></member>'
+      '<member><name>faultString</name>'
+      '<value><string>Could not create download</string></value></member>'
+      '</struct></value></fault></methodResponse>';
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.path;
+
+    if (path.endsWith('/test.torrent')) {
+      return ResponseBody.fromBytes(
+        Uint8List.fromList(torrentFileBytes),
+        200,
+        headers: {
+          Headers.contentTypeHeader: ['application/x-bittorrent'],
+        },
+      );
+    }
+
+    if (path.endsWith('/plugins/httprpc/action.php')) {
+      final body = await _readBody(requestStream);
+
+      if (body.contains('mode=list')) {
+        return ResponseBody.fromString(
+          jsonEncode({'t': torrents}),
+          200,
+          headers: {
+            Headers.contentTypeHeader: [Headers.jsonContentType],
+          },
+        );
+      }
+
+      if (body.contains('d.multicall2')) {
+        if (failTimeCustoms) {
+          return ResponseBody.fromString('Internal Server Error', 500);
+        }
+        return ResponseBody.fromString(
+          _multicallResponse(),
+          200,
+          headers: {
+            Headers.contentTypeHeader: ['text/xml'],
+          },
+        );
+      }
+
+      if (body.contains('<methodName>execute2</methodName>')) {
+        mkdirRequests.add(body);
+        return ResponseBody.fromString(
+          failMkdir ? _faultResponse : _successResponse,
+          200,
+          headers: {
+            Headers.contentTypeHeader: ['text/xml'],
+          },
+        );
+      }
+
+      if (body.contains('load.')) {
+        xmlRequests.add(body);
+        return ResponseBody.fromString(
+          faultOnLoad ? _faultResponse : _successResponse,
+          200,
+          headers: {
+            Headers.contentTypeHeader: ['text/xml'],
+          },
+        );
+      }
+    }
+
+    if (path.endsWith('/php/addtorrent.php')) {
+      final bytes = <int>[];
+      if (requestStream != null) {
+        await for (final chunk in requestStream) {
+          bytes.addAll(chunk);
+        }
+      }
+      uploadRequests.add(utf8.decode(bytes, allowMalformed: true));
+
+      if (addTorrentRespondJson) {
+        return ResponseBody.fromString(
+          jsonEncode({'result': addTorrentResult}),
+          200,
+          headers: {
+            Headers.contentTypeHeader: [Headers.jsonContentType],
+          },
+        );
+      }
+      // 官方行为：无条件302，结果在Location的result[]参数中
+      return ResponseBody.fromString(
+        '',
+        302,
+        headers: {
+          'location': [
+            '//localhost/php/addtorrent.php?result[]=$addTorrentResult&json=1',
+          ],
+        },
+      );
+    }
+
+    throw UnsupportedError('Unexpected request: ${options.method} $path');
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  group('RuTorrentClient', () {
+    RuTorrentClient buildClient(
+      _FakeHttpClientAdapter adapter, {
+      bool useLocalRelay = true,
+    }) {
+      final dio = Dio()..httpClientAdapter = adapter;
+      return RuTorrentClient(
+        config: RuTorrentConfig(
+          id: 'rt-1',
+          name: 'rt',
+          host: 'http://localhost',
+          port: 80,
+          username: 'admin',
+          password: '',
+          useLocalRelay: useLocalRelay,
+        ),
+        password: 'secret',
+        dio: dio,
+      );
+    }
+
+    test('getTasks maps downloading state and progress', () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrents = {
+          'AAAA0000AAAA0000AAAA0000AAAA0000AAAA0000': buildRawTorrent(
+            label: Uri.encodeComponent('电影'),
+          ),
+        };
+
+      final tasks = await buildClient(adapter).getTasks();
+
+      expect(tasks.length, 1);
+      final task = tasks.first;
+      expect(task.hash, 'aaaa0000aaaa0000aaaa0000aaaa0000aaaa0000');
+      expect(task.state, DownloadTaskState.downloading);
+      expect(task.progress, closeTo(0.5, 0.001));
+      expect(task.dlspeed, 20);
+      expect(task.upspeed, 10);
+      expect(task.category, '电影');
+      // basePath 末段与名称相同时取父目录
+      expect(task.contentPath, '/downloads');
+    });
+
+    test('getTasks uses addtime custom for addedOn', () async {
+      const hash = 'AAAA0000AAAA0000AAAA0000AAAA0000AAAA0000';
+      final adapter = _FakeHttpClientAdapter()
+        ..torrents = {hash: buildRawTorrent(created: '1600000000')}
+        ..timeCustoms = {
+          hash: ['1700000000', '1710000000'],
+        };
+
+      final tasks = await buildClient(adapter).getTasks();
+
+      expect(tasks.first.addedOn, 1700000000);
+      expect(tasks.first.completionOn, 1710000000);
+    });
+
+    test('getTasks falls back to creation date without addtime', () async {
+      const hash = 'BBBB0000BBBB0000BBBB0000BBBB0000BBBB0000';
+      final adapter = _FakeHttpClientAdapter()
+        ..torrents = {hash: buildRawTorrent(created: '1600000000')}
+        ..timeCustoms = {
+          hash: ['', ''],
+        };
+
+      final tasks = await buildClient(adapter).getTasks();
+
+      expect(tasks.first.addedOn, 1600000000);
+      expect(tasks.first.completionOn, 0);
+    });
+
+    test('getTasks survives time-custom fetch failure', () async {
+      const hash = 'CCCC0000CCCC0000CCCC0000CCCC0000CCCC0000';
+      final adapter = _FakeHttpClientAdapter()
+        ..torrents = {hash: buildRawTorrent(created: '1600000000')}
+        ..failTimeCustoms = true;
+
+      final tasks = await buildClient(adapter).getTasks();
+
+      expect(tasks.length, 1);
+      expect(tasks.first.addedOn, 1600000000);
+    });
+
+    test('getTasks maps paused and stopped states', () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrents = {
+          'D000000000000000000000000000000000000001': buildRawTorrent(
+            getState: '0',
+          ),
+          'D000000000000000000000000000000000000002': buildRawTorrent(
+            isOpen: '0',
+          ),
+          'D000000000000000000000000000000000000003': buildRawTorrent(
+            completedChunks: '100',
+          ),
+        };
+
+      final tasks = await buildClient(adapter).getTasks();
+      final byHash = {for (final t in tasks) t.hash.toUpperCase(): t};
+
+      expect(
+        byHash['D000000000000000000000000000000000000001']!.state,
+        DownloadTaskState.pausedDL,
+      );
+      expect(
+        byHash['D000000000000000000000000000000000000002']!.state,
+        DownloadTaskState.unknown,
+      );
+      expect(
+        byHash['D000000000000000000000000000000000000003']!.state,
+        DownloadTaskState.uploading,
+      );
+    });
+
+    test('addTask magnet uses load.start with commands', () async {
+      final adapter = _FakeHttpClientAdapter();
+      final client = buildClient(adapter, useLocalRelay: false);
+
+      await client.addTask(
+        AddTaskParams(
+          url: 'magnet:?xt=urn:btih:abcdef0123456789',
+          savePath: '/data',
+          category: '电影',
+        ),
+      );
+
+      expect(adapter.xmlRequests.length, 1);
+      final xml = adapter.xmlRequests.first;
+      expect(xml, contains('<methodName>load.start</methodName>'));
+      expect(xml, contains('magnet:?xt=urn:btih:abcdef0123456789'));
+      expect(xml, contains('d.custom.set=addtime,'));
+      expect(xml, contains('d.directory.set="/data"'));
+      expect(
+        xml,
+        contains('d.custom1.set=${Uri.encodeComponent('电影')}'),
+      );
+    });
+
+    test('addTask magnet with startPaused uses load.normal', () async {
+      final adapter = _FakeHttpClientAdapter();
+      final client = buildClient(adapter, useLocalRelay: false);
+
+      await client.addTask(
+        AddTaskParams(url: 'magnet:?xt=urn:btih:abcdef', startPaused: true),
+      );
+
+      expect(
+        adapter.xmlRequests.single,
+        contains('<methodName>load.normal</methodName>'),
+      );
+    });
+
+    test('addTask torrent url downloads file and uses load.raw_start',
+        () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrentFileBytes = [1, 2, 3, 4];
+      final client = buildClient(adapter);
+
+      await client.addTask(
+        AddTaskParams(url: 'https://example.com/test.torrent'),
+      );
+
+      final xml = adapter.xmlRequests.single;
+      expect(xml, contains('<methodName>load.raw_start</methodName>'));
+      expect(xml, contains('<base64>${base64Encode([1, 2, 3, 4])}</base64>'));
+    });
+
+    test('addTask creates missing save directory via execute2 mkdir -p',
+        () async {
+      final adapter = _FakeHttpClientAdapter();
+      final client = buildClient(adapter, useLocalRelay: false);
+
+      await client.addTask(
+        AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: '/data/new'),
+      );
+
+      final mkdir = adapter.mkdirRequests.single;
+      expect(mkdir, contains('<methodName>execute2</methodName>'));
+      expect(mkdir, contains('<string>mkdir</string>'));
+      expect(mkdir, contains('<string>-p</string>'));
+      expect(mkdir, contains('<string>/data/new</string>'));
+      expect(
+        adapter.xmlRequests.single,
+        contains('d.directory.set="/data/new"'),
+      );
+    });
+
+    test('addTask torrent file with savePath creates directory first',
+        () async {
+      final adapter = _FakeHttpClientAdapter()..torrentFileBytes = [1, 2, 3, 4];
+      final client = buildClient(adapter);
+
+      await client.addTask(
+        AddTaskParams(
+          url: 'https://example.com/test.torrent',
+          savePath: '/data/new',
+        ),
+      );
+
+      expect(adapter.mkdirRequests, hasLength(1));
+      expect(adapter.xmlRequests.single, contains('load.raw_start'));
+    });
+
+    test('addTask proceeds when mkdir reports fault (official behavior)',
+        () async {
+      final adapter = _FakeHttpClientAdapter()..failMkdir = true;
+      final client = buildClient(adapter, useLocalRelay: false);
+
+      await client.addTask(
+        AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: '/data/new'),
+      );
+
+      // mkdir失败不阻断加载，与官方multicall行为一致
+      expect(adapter.xmlRequests.single, contains('load.start'));
+    });
+
+    test('addTask rejects save path with illegal characters', () async {
+      final adapter = _FakeHttpClientAdapter();
+      final client = buildClient(adapter, useLocalRelay: false);
+
+      await expectLater(
+        client.addTask(
+          AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: '/da"ta\n'),
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('FailedDirectory'),
+          ),
+        ),
+      );
+
+      // 校验在任何请求发出前完成
+      expect(adapter.mkdirRequests, isEmpty);
+      expect(adapter.xmlRequests, isEmpty);
+    });
+
+    test('addTask non-absolute savePath skips client-side mkdir', () async {
+      final adapter = _FakeHttpClientAdapter();
+      final client = buildClient(adapter, useLocalRelay: false);
+
+      await client.addTask(
+        AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: 'tv/season1'),
+      );
+
+      // ~与相对路径需由服务端解析，客户端不发mkdir，仅设置目录
+      expect(adapter.mkdirRequests, isEmpty);
+      expect(
+        adapter.xmlRequests.single,
+        contains('d.directory.set="tv/season1"'),
+      );
+    });
+
+    // ruTorrent官方上限RTORRENT_PACKET_LIMIT=1572864按base64后长度比较：
+    // 原始1179645字节 -> base64 1572860（未达上限，走load.raw）
+    // 原始1179646字节 -> base64 1572864（达到上限，走addtorrent.php）
+    test('addTask torrent at packet limit boundary stays on load.raw',
+        () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrentFileBytes = List.filled(1179645, 0);
+      final client = buildClient(adapter);
+
+      await client.addTask(
+        AddTaskParams(url: 'https://example.com/test.torrent'),
+      );
+
+      expect(adapter.uploadRequests, isEmpty);
+      expect(adapter.xmlRequests.single, contains('load.raw_start'));
+    });
+
+    test('addTask large torrent falls back to addtorrent.php multipart',
+        () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrentFileBytes = List.filled(1179646, 0);
+      final client = buildClient(adapter);
+
+      await client.addTask(
+        AddTaskParams(
+          url: 'https://example.com/test.torrent',
+          savePath: '/data',
+          category: '电影',
+          startPaused: true,
+        ),
+      );
+
+      // 未经XML-RPC提交，且302被视为成功
+      expect(adapter.xmlRequests, isEmpty);
+      final body = adapter.uploadRequests.single;
+      expect(body, contains('name="torrent_file"'));
+      expect(body, contains('name="json"'));
+      expect(body, contains('name="dir_edit"'));
+      expect(body, contains('/data'));
+      expect(body, contains('name="label"'));
+      expect(body, contains('电影'));
+      expect(body, contains('name="torrents_start_stopped"'));
+    });
+
+    test('addTask large torrent omits optional fields when unset', () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrentFileBytes = List.filled(1179646, 0);
+      final client = buildClient(adapter);
+
+      await client.addTask(
+        AddTaskParams(url: 'https://example.com/test.torrent'),
+      );
+
+      final body = adapter.uploadRequests.single;
+      expect(body, isNot(contains('name="dir_edit"')));
+      expect(body, isNot(contains('name="label"')));
+      expect(body, isNot(contains('name="torrents_start_stopped"')));
+    });
+
+    test('addTask throws when addtorrent.php reports failure', () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrentFileBytes = List.filled(1179646, 0)
+        ..addTorrentResult = 'FailedFile';
+      final client = buildClient(adapter);
+
+      expect(
+        () => client.addTask(
+          AddTaskParams(url: 'https://example.com/test.torrent'),
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('FailedFile'),
+          ),
+        ),
+      );
+    });
+
+    test('addTask accepts JSON result when redirect already followed',
+        () async {
+      final adapter = _FakeHttpClientAdapter()
+        ..torrentFileBytes = List.filled(1179646, 0)
+        ..addTorrentRespondJson = true;
+      final client = buildClient(adapter);
+
+      await client.addTask(
+        AddTaskParams(url: 'https://example.com/test.torrent'),
+      );
+
+      expect(adapter.uploadRequests, hasLength(1));
+    });
+
+    test('addTask throws on XML-RPC fault', () async {
+      final adapter = _FakeHttpClientAdapter()..faultOnLoad = true;
+      final client = buildClient(adapter, useLocalRelay: false);
+
+      expect(
+        () => client.addTask(AddTaskParams(url: 'magnet:?xt=urn:btih:abc')),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Could not create download'),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/services/downloader/rutorrent_client_test.dart
+++ b/test/services/downloader/rutorrent_client_test.dart
@@ -82,14 +82,8 @@ class _FakeHttpClientAdapter implements HttpClientAdapter {
   /// 种子文件下载内容
   List<int> torrentFileBytes = [1, 2, 3, 4];
 
-  /// 记录发往 addtorrent.php 的multipart请求体
+  /// 记录发往 addtorrent.php 的表单请求体
   final List<String> uploadRequests = [];
-
-  /// 记录 execute2 mkdir 请求体
-  final List<String> mkdirRequests = [];
-
-  /// mkdir 命令返回 fault
-  bool failMkdir = false;
 
   /// addtorrent.php 通过302 Location返回的result[]值
   String addTorrentResult = 'Success';
@@ -173,17 +167,6 @@ class _FakeHttpClientAdapter implements HttpClientAdapter {
         }
         return ResponseBody.fromString(
           _multicallResponse(),
-          200,
-          headers: {
-            Headers.contentTypeHeader: ['text/xml'],
-          },
-        );
-      }
-
-      if (body.contains('<methodName>execute2</methodName>')) {
-        mkdirRequests.add(body);
-        return ResponseBody.fromString(
-          failMkdir ? _faultResponse : _successResponse,
           200,
           headers: {
             Headers.contentTypeHeader: ['text/xml'],
@@ -355,7 +338,7 @@ void main() {
       );
     });
 
-    test('addTask magnet uses load.start with commands', () async {
+    test('addTask magnet with savePath uses addtorrent.php', () async {
       final adapter = _FakeHttpClientAdapter();
       final client = buildClient(adapter, useLocalRelay: false);
 
@@ -364,19 +347,21 @@ void main() {
           url: 'magnet:?xt=urn:btih:abcdef0123456789',
           savePath: '/data',
           category: '电影',
+          startPaused: true,
         ),
       );
 
-      expect(adapter.xmlRequests.length, 1);
-      final xml = adapter.xmlRequests.first;
-      expect(xml, contains('<methodName>load.start</methodName>'));
-      expect(xml, contains('magnet:?xt=urn:btih:abcdef0123456789'));
-      expect(xml, contains('d.custom.set=addtime,'));
-      expect(xml, contains('d.directory.set="/data"'));
-      expect(
-        xml,
-        contains('d.custom1.set=${Uri.encodeComponent('电影')}'),
-      );
+      expect(adapter.xmlRequests, isEmpty);
+      final body = adapter.uploadRequests.single;
+      expect(body, contains('name="url"'));
+      expect(body, contains('magnet:?xt=urn:btih:abcdef0123456789'));
+      expect(body, contains('name="dir_edit"'));
+      expect(body, contains('/data'));
+      expect(body, contains('name="label"'));
+      expect(body, contains('电影'));
+      expect(body, contains('name="torrents_start_stopped"'));
+      expect(body, contains('name="addition[]"'));
+      expect(body, contains('d.custom.set=addtime,'));
     });
 
     test('addTask magnet with startPaused uses load.normal', () async {
@@ -393,77 +378,55 @@ void main() {
       );
     });
 
-    test('addTask torrent url downloads file and uses load.raw_start',
-        () async {
+    test(
+      'addTask torrent url downloads file and uses load.raw_start',
+      () async {
+        final adapter = _FakeHttpClientAdapter()
+          ..torrentFileBytes = [1, 2, 3, 4];
+        final client = buildClient(adapter);
+
+        await client.addTask(
+          AddTaskParams(url: 'https://example.com/test.torrent'),
+        );
+
+        final xml = adapter.xmlRequests.single;
+        expect(xml, contains('<methodName>load.raw_start</methodName>'));
+        expect(xml, contains('<base64>${base64Encode([1, 2, 3, 4])}</base64>'));
+      },
+    );
+
+    test(
+      'addTask small torrent with savePath uses addtorrent.php multipart',
+      () async {
+        final adapter = _FakeHttpClientAdapter()
+          ..torrentFileBytes = [1, 2, 3, 4];
+        final client = buildClient(adapter);
+
+        await client.addTask(
+          AddTaskParams(
+            url: 'https://example.com/test.torrent',
+            savePath: '/data/new',
+          ),
+        );
+
+        expect(adapter.xmlRequests, isEmpty);
+        final body = adapter.uploadRequests.single;
+        expect(body, contains('name="torrent_file"'));
+        expect(body, contains('name="dir_edit"'));
+        expect(body, contains('/data/new'));
+        expect(body, contains('name="addition[]"'));
+        expect(body, contains('d.custom.set=addtime,'));
+      },
+    );
+
+    test('addTask propagates FailedDirectory from addtorrent.php', () async {
       final adapter = _FakeHttpClientAdapter()
-        ..torrentFileBytes = [1, 2, 3, 4];
-      final client = buildClient(adapter);
-
-      await client.addTask(
-        AddTaskParams(url: 'https://example.com/test.torrent'),
-      );
-
-      final xml = adapter.xmlRequests.single;
-      expect(xml, contains('<methodName>load.raw_start</methodName>'));
-      expect(xml, contains('<base64>${base64Encode([1, 2, 3, 4])}</base64>'));
-    });
-
-    test('addTask creates missing save directory via execute2 mkdir -p',
-        () async {
-      final adapter = _FakeHttpClientAdapter();
+        ..addTorrentResult = 'FailedDirectory';
       final client = buildClient(adapter, useLocalRelay: false);
 
-      await client.addTask(
-        AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: '/data/new'),
-      );
-
-      final mkdir = adapter.mkdirRequests.single;
-      expect(mkdir, contains('<methodName>execute2</methodName>'));
-      expect(mkdir, contains('<string>mkdir</string>'));
-      expect(mkdir, contains('<string>-p</string>'));
-      expect(mkdir, contains('<string>/data/new</string>'));
       expect(
-        adapter.xmlRequests.single,
-        contains('d.directory.set="/data/new"'),
-      );
-    });
-
-    test('addTask torrent file with savePath creates directory first',
-        () async {
-      final adapter = _FakeHttpClientAdapter()..torrentFileBytes = [1, 2, 3, 4];
-      final client = buildClient(adapter);
-
-      await client.addTask(
-        AddTaskParams(
-          url: 'https://example.com/test.torrent',
-          savePath: '/data/new',
-        ),
-      );
-
-      expect(adapter.mkdirRequests, hasLength(1));
-      expect(adapter.xmlRequests.single, contains('load.raw_start'));
-    });
-
-    test('addTask proceeds when mkdir reports fault (official behavior)',
-        () async {
-      final adapter = _FakeHttpClientAdapter()..failMkdir = true;
-      final client = buildClient(adapter, useLocalRelay: false);
-
-      await client.addTask(
-        AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: '/data/new'),
-      );
-
-      // mkdir失败不阻断加载，与官方multicall行为一致
-      expect(adapter.xmlRequests.single, contains('load.start'));
-    });
-
-    test('addTask rejects save path with illegal characters', () async {
-      final adapter = _FakeHttpClientAdapter();
-      final client = buildClient(adapter, useLocalRelay: false);
-
-      await expectLater(
-        client.addTask(
-          AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: '/da"ta\n'),
+        () => client.addTask(
+          AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: '/invalid'),
         ),
         throwsA(
           isA<Exception>().having(
@@ -473,71 +436,55 @@ void main() {
           ),
         ),
       );
-
-      // 校验在任何请求发出前完成
-      expect(adapter.mkdirRequests, isEmpty);
-      expect(adapter.xmlRequests, isEmpty);
-    });
-
-    test('addTask non-absolute savePath skips client-side mkdir', () async {
-      final adapter = _FakeHttpClientAdapter();
-      final client = buildClient(adapter, useLocalRelay: false);
-
-      await client.addTask(
-        AddTaskParams(url: 'magnet:?xt=urn:btih:abc', savePath: 'tv/season1'),
-      );
-
-      // ~与相对路径需由服务端解析，客户端不发mkdir，仅设置目录
-      expect(adapter.mkdirRequests, isEmpty);
-      expect(
-        adapter.xmlRequests.single,
-        contains('d.directory.set="tv/season1"'),
-      );
     });
 
     // ruTorrent官方上限RTORRENT_PACKET_LIMIT=1572864按base64后长度比较：
     // 原始1179645字节 -> base64 1572860（未达上限，走load.raw）
     // 原始1179646字节 -> base64 1572864（达到上限，走addtorrent.php）
-    test('addTask torrent at packet limit boundary stays on load.raw',
-        () async {
-      final adapter = _FakeHttpClientAdapter()
-        ..torrentFileBytes = List.filled(1179645, 0);
-      final client = buildClient(adapter);
+    test(
+      'addTask torrent at packet limit boundary stays on load.raw',
+      () async {
+        final adapter = _FakeHttpClientAdapter()
+          ..torrentFileBytes = List.filled(1179645, 0);
+        final client = buildClient(adapter);
 
-      await client.addTask(
-        AddTaskParams(url: 'https://example.com/test.torrent'),
-      );
+        await client.addTask(
+          AddTaskParams(url: 'https://example.com/test.torrent'),
+        );
 
-      expect(adapter.uploadRequests, isEmpty);
-      expect(adapter.xmlRequests.single, contains('load.raw_start'));
-    });
+        expect(adapter.uploadRequests, isEmpty);
+        expect(adapter.xmlRequests.single, contains('load.raw_start'));
+      },
+    );
 
-    test('addTask large torrent falls back to addtorrent.php multipart',
-        () async {
-      final adapter = _FakeHttpClientAdapter()
-        ..torrentFileBytes = List.filled(1179646, 0);
-      final client = buildClient(adapter);
+    test(
+      'addTask large torrent falls back to addtorrent.php multipart',
+      () async {
+        final adapter = _FakeHttpClientAdapter()
+          ..torrentFileBytes = List.filled(1179646, 0);
+        final client = buildClient(adapter);
 
-      await client.addTask(
-        AddTaskParams(
-          url: 'https://example.com/test.torrent',
-          savePath: '/data',
-          category: '电影',
-          startPaused: true,
-        ),
-      );
+        await client.addTask(
+          AddTaskParams(
+            url: 'https://example.com/test.torrent',
+            category: '电影',
+            startPaused: true,
+          ),
+        );
 
-      // 未经XML-RPC提交，且302被视为成功
-      expect(adapter.xmlRequests, isEmpty);
-      final body = adapter.uploadRequests.single;
-      expect(body, contains('name="torrent_file"'));
-      expect(body, contains('name="json"'));
-      expect(body, contains('name="dir_edit"'));
-      expect(body, contains('/data'));
-      expect(body, contains('name="label"'));
-      expect(body, contains('电影'));
-      expect(body, contains('name="torrents_start_stopped"'));
-    });
+        // 未经XML-RPC提交，且302被视为成功
+        expect(adapter.xmlRequests, isEmpty);
+        final body = adapter.uploadRequests.single;
+        expect(body, contains('name="torrent_file"'));
+        expect(body, contains('name="json"'));
+        expect(body, isNot(contains('name="dir_edit"')));
+        expect(body, contains('name="label"'));
+        expect(body, contains('电影'));
+        expect(body, contains('name="torrents_start_stopped"'));
+        expect(body, contains('name="addition[]"'));
+        expect(body, contains('d.custom.set=addtime,'));
+      },
+    );
 
     test('addTask large torrent omits optional fields when unset', () async {
       final adapter = _FakeHttpClientAdapter()
@@ -552,6 +499,8 @@ void main() {
       expect(body, isNot(contains('name="dir_edit"')));
       expect(body, isNot(contains('name="label"')));
       expect(body, isNot(contains('name="torrents_start_stopped"')));
+      expect(body, contains('name="addition[]"'));
+      expect(body, contains('d.custom.set=addtime,'));
     });
 
     test('addTask throws when addtorrent.php reports failure', () async {
@@ -574,19 +523,21 @@ void main() {
       );
     });
 
-    test('addTask accepts JSON result when redirect already followed',
-        () async {
-      final adapter = _FakeHttpClientAdapter()
-        ..torrentFileBytes = List.filled(1179646, 0)
-        ..addTorrentRespondJson = true;
-      final client = buildClient(adapter);
+    test(
+      'addTask accepts JSON result when redirect already followed',
+      () async {
+        final adapter = _FakeHttpClientAdapter()
+          ..torrentFileBytes = List.filled(1179646, 0)
+          ..addTorrentRespondJson = true;
+        final client = buildClient(adapter);
 
-      await client.addTask(
-        AddTaskParams(url: 'https://example.com/test.torrent'),
-      );
+        await client.addTask(
+          AddTaskParams(url: 'https://example.com/test.torrent'),
+        );
 
-      expect(adapter.uploadRequests, hasLength(1));
-    });
+        expect(adapter.uploadRequests, hasLength(1));
+      },
+    );
 
     test('addTask throws on XML-RPC fault', () async {
       final adapter = _FakeHttpClientAdapter()..faultOnLoad = true;


### PR DESCRIPTION
## 变更内容

- ruTorrent 下载器添加种子时使用 XML-RPC 重构，避免 302 返回码问题
- 重构 getTask 支持按照添加时间排序
