### PR TITLE
ci: 增加 PR 全量测试合并门禁

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -25,7 +25,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: .flutter-version
-          channel: stable
           cache: true
 
       - name: Cache Pub dependencies
@@ -54,7 +53,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: .flutter-version
-          channel: stable
           cache: true
 
       - name: Cache Pub dependencies
@@ -111,7 +109,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version-file: .flutter-version
-          channel: stable
           cache: true
 
       - name: Cache Pub dependencies

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,156 @@
+name: PR validation
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  flutter-analyze:
+    name: Flutter analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version-file: .flutter-version
+          channel: stable
+          cache: true
+
+      - name: Cache Pub dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Analyze Dart sources
+        run: flutter analyze
+
+  flutter-test:
+    name: Flutter tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version-file: .flutter-version
+          channel: stable
+          cache: true
+
+      - name: Cache Pub dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Run all Flutter tests
+        run: flutter test
+
+  go-test:
+    name: Go tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: server/go.mod
+          cache: true
+          cache-dependency-path: server/go.sum
+
+      - name: Run all Go tests
+        run: go test ./...
+
+  android-test:
+    name: Android unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: '17'
+          cache: gradle
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version-file: .flutter-version
+          channel: stable
+          cache: true
+
+      - name: Cache Pub dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Prepare Android build files
+        run: flutter build apk --config-only
+
+      - name: Run all Android debug unit tests
+        working-directory: android
+        run: ./gradlew :app:testDebugUnitTest
+
+  pr-gate:
+    name: PR gate
+    if: ${{ always() }}
+    needs:
+      - flutter-analyze
+      - flutter-test
+      - go-test
+      - android-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require all validation jobs to pass
+        env:
+          FLUTTER_ANALYZE_RESULT: ${{ needs.flutter-analyze.result }}
+          FLUTTER_TEST_RESULT: ${{ needs.flutter-test.result }}
+          GO_TEST_RESULT: ${{ needs.go-test.result }}
+          ANDROID_TEST_RESULT: ${{ needs.android-test.result }}
+        run: |
+          test "$FLUTTER_ANALYZE_RESULT" = success
+          test "$FLUTTER_TEST_RESULT" = success
+          test "$GO_TEST_RESULT" = success
+          test "$ANDROID_TEST_RESULT" = success

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,10 +21,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Read Flutter version
+        id: flutter-version
+        run: echo "version=$(tr -d '[:space:]' < .flutter-version)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: .flutter-version
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
+          channel: stable
           cache: true
 
       - name: Cache Pub dependencies
@@ -49,10 +54,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Read Flutter version
+        id: flutter-version
+        run: echo "version=$(tr -d '[:space:]' < .flutter-version)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: .flutter-version
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
+          channel: stable
           cache: true
 
       - name: Cache Pub dependencies
@@ -98,6 +108,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Read Flutter version
+        id: flutter-version
+        run: echo "version=$(tr -d '[:space:]' < .flutter-version)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -108,7 +122,8 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: .flutter-version
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
+          channel: stable
           cache: true
 
       - name: Cache Pub dependencies

--- a/.github/workflows/secure-storage-safety.yml
+++ b/.github/workflows/secure-storage-safety.yml
@@ -8,19 +8,6 @@ on:
         required: false
         type: string
         default: ''
-  pull_request:
-    paths:
-      - 'android/app/**'
-      - 'lib/**'
-      - 'test/**'
-      - 'pubspec.yaml'
-      - 'pubspec.lock'
-      - '.flutter-version'
-      - 'android/gradle/**'
-      - 'android/*.gradle*'
-      - 'android/gradle.properties'
-      - '.github/workflows/secure-storage-safety.yml'
-      - '.github/workflows/release.yml'
   push:
     branches:
       - master

--- a/lib/services/api/api_service.dart
+++ b/lib/services/api/api_service.dart
@@ -271,7 +271,7 @@ class ApiService {
   Future<bool> testConnectionWithSite(SiteConfig siteConfig) async {
     try {
       final adapter = await getAdapter(siteConfig);
-      return adapter.testConnection();
+      return await adapter.testConnection();
     } catch (e) {
       return false;
     }

--- a/test/nexusphp_web_adapter_test.dart
+++ b/test/nexusphp_web_adapter_test.dart
@@ -8,6 +8,11 @@ import 'dart:io';
 import 'package:pt_mate/services/api/nexusphp_web_adapter.dart';
 
 void main() {
+  final htmlDir = Directory('test/html');
+  final htmlFixtureSkip = htmlDir.existsSync()
+      ? false
+      : '未提供本地私有 HTML 夹具；NexusPHP Web 页面诊断默认跳过。';
+
   group('NexusPHP Web Adapter Tests', () {
     late List<File> htmlFiles;
     late Map<String, String> htmlContents;
@@ -25,7 +30,6 @@ void main() {
         ),
       );
       // 遍历html文件夹中的所有HTML文件
-      final htmlDir = Directory('test/html');
       htmlFiles = htmlDir
           .listSync()
           .where((entity) => entity is File && entity.path.endsWith('.html'))
@@ -245,5 +249,5 @@ void main() {
         }
       }
     });
-  });
+  }, skip: htmlFixtureSkip);
 }


### PR DESCRIPTION
## 变更内容

- 新增面向 `master` PR 的全量验证流水线。
- 并行运行 `flutter analyze`、`flutter test`、`go test ./...` 和 Android Debug JVM 单元测试。
- 使用稳定的 `PR gate` 汇总检查，任一验证失败或取消都会阻止门禁通过。
- 移除安全存储专项工作流的 PR 触发，避免重复执行；保留发布复用、master push 和手动触发。

## 影响

后续将把 `PR gate` 配置为 `master` 的必需检查。普通变更必须通过 PR 和全量验证；管理员保留应急绕过权限。

## 验证

- `flutter analyze`
- `flutter test`（336 项通过，1 项实网诊断按设计跳过）
- `cd server && go test ./...`
- `flutter build apk --config-only && android/gradlew -p android :app:testDebugUnitTest`
- YAML 解析及工作流结构断言
