### PR TITLE
fix: 锁定 CI Flutter SDK 版本

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -17,6 +17,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Read Flutter version
+        id: flutter-version
+        shell: bash
+        run: |
+          version="$(tr -d '[:space:]' < .flutter-version)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -30,7 +38,7 @@ jobs:
         id: cache_flutter_linux
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: .flutter-version
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -122,6 +130,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Read Flutter version
+        id: flutter-version
+        shell: bash
+        run: |
+          version="$(tr -d '[:space:]' < .flutter-version)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -132,7 +148,7 @@ jobs:
         id: cache_flutter_windows
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: .flutter-version
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -183,11 +199,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Read Flutter version
+        id: flutter-version
+        shell: bash
+        run: |
+          version="$(tr -d '[:space:]' < .flutter-version)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Setup Flutter (cached)
         id: cache_flutter_macos
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: .flutter-version
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
           channel: 'stable'
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,14 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: '17'
+
+    - name: Read Flutter version
+      id: flutter-version
+      shell: bash
+      run: |
+        version="$(tr -d '[:space:]' < .flutter-version)"
+        test -n "$version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
         
     - name: Get Java Version
       run: echo "JAVA_VERSION=$(java -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | awk '{print $3}')" >> $GITHUB_ENV
@@ -141,7 +149,7 @@ jobs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version-file: .flutter-version
+        flutter-version: ${{ steps.flutter-version.outputs.version }}
         channel: 'stable'
         cache: true  # 启用 Flutter SDK 缓存
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -347,12 +355,20 @@ jobs:
       with:
         distribution: 'zulu'
         java-version: '17'
+
+    - name: Read Flutter version
+      id: flutter-version
+      shell: bash
+      run: |
+        version="$(tr -d '[:space:]' < .flutter-version)"
+        test -n "$version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
         
     # Flutter SDK 缓存
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version-file: .flutter-version
+        flutter-version: ${{ steps.flutter-version.outputs.version }}
         channel: 'stable'
         cache: true  # 启用 Flutter SDK 缓存
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
@@ -436,12 +452,20 @@ jobs:
         VERSION=${TAG#v}
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+    - name: Read Flutter version
+      id: flutter-version
+      shell: bash
+      run: |
+        version="$(tr -d '[:space:]' < .flutter-version)"
+        test -n "$version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
         
     # Flutter SDK 缓存
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version-file: .flutter-version
+        flutter-version: ${{ steps.flutter-version.outputs.version }}
         channel: 'stable'
         cache: true  # 启用 Flutter SDK 缓存
         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'

--- a/.github/workflows/secure-storage-safety.yml
+++ b/.github/workflows/secure-storage-safety.yml
@@ -37,10 +37,18 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Read Flutter version
+        id: flutter-version
+        shell: bash
+        run: |
+          version="$(tr -d '[:space:]' < .flutter-version)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: .flutter-version
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
           channel: stable
           cache: true
 


### PR DESCRIPTION
## 问题

缓存预热、发布和安全存储工作流把纯文本 `.flutter-version` 传给 `flutter-version-file`。`subosito/flutter-action@v2` 会将普通文件按 YAML 的 `environment.flutter` 解析，解析为空后退化到最新 stable，导致 macOS 缓存预热从 Flutter 3.44.9 漂移到 3.47.0，并触发 CocoaPods 最低部署版本冲突。

## 修复

- 在 Linux、Windows、macOS job 中显式读取 `.flutter-version`
- 校验版本值非空后传给 `flutter-version`
- 缓存预热、发布、安全存储共 7 处统一锁定到 3.44.4
- 不修改依赖锁文件或 iOS/macOS 最低版本

## 验证

- 相关 workflow YAML 均可解析
- 仓库中 `flutter-version-file: .flutter-version` 已归零
- 7 个 Flutter Action 初始化均引用统一版本输出
- `.flutter-version` 断言为 3.44.4

关联失败任务：https://github.com/JustLookAtNow/pt_mate/actions/runs/31665503979/job/94339076325