### PR TITLE
feat: 封面查看器支持左右翻页并联动滚动列表

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -14,6 +14,7 @@ import 'pages/torrent_detail_page.dart';
 import 'pages/backup_restore_page.dart';
 import 'pages/secure_storage_recovery_page.dart';
 import 'services/api/api_service.dart';
+import 'services/image_http_client.dart';
 import 'services/settings/display_settings_manager.dart';
 import 'services/storage/storage_service.dart';
 import 'services/theme/theme_manager.dart';
@@ -38,6 +39,8 @@ import 'widgets/responsive_layout.dart';
 import 'widgets/torrent_download_dialog.dart';
 import 'widgets/torrent_list_item.dart';
 import 'widgets/torrent_list_skeleton.dart';
+import 'widgets/torrent_cover_gallery_viewer.dart';
+import 'widgets/list_index_scroller.dart';
 import 'widgets/tag_filter_bar.dart';
 import 'services/update_service.dart';
 import 'widgets/update_notification_dialog.dart';
@@ -1431,6 +1434,10 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   final _keywordCtrl = TextEditingController();
   final ScrollController _scrollCtrl = ScrollController();
+  late final ListIndexScroller _listScroller = ListIndexScroller(
+    controller: _scrollCtrl,
+    listViewKey: _listKey,
+  );
 
   int _selectedCategoryIndex = 0;
   List<SearchCategoryConfig> _categories = [];
@@ -2307,6 +2314,67 @@ class _HomePageState extends State<HomePage> {
     if (mounted) setState(() {}); // 触发重建以显示排序结果
   }
 
+  /// 打开封面画廊查看器，可左右翻页并联动滚动列表。
+  void _openCoverGallery(int listIndex) {
+    final items = _filteredItems;
+    if (listIndex < 0 || listIndex >= items.length) return;
+    if (items[listIndex].cover.isEmpty) return;
+
+    // 有封面条目的下标列表（画廊 position ↔ 列表下标映射）
+    final coverIndices = <int>[
+      for (var i = 0; i < items.length; i++)
+        if (items[i].cover.isNotEmpty) i,
+    ];
+    final initialPosition = coverIndices.indexOf(listIndex);
+    if (initialPosition == -1) return;
+
+    showDialog(
+      context: context,
+      barrierColor: Colors.black.withValues(alpha: 0.7),
+      builder: (dialogContext) {
+        return TorrentCoverGalleryViewer(
+          itemCount: coverIndices.length,
+          initialIndex: initialPosition,
+          titleFor: (position) {
+            final i = (position >= 0 && position < coverIndices.length)
+                ? coverIndices[position]
+                : null;
+            return (i != null && i < _filteredItems.length)
+                ? _filteredItems[i].name
+                : '';
+          },
+          loadCover: (position) async {
+            final i = (position >= 0 && position < coverIndices.length)
+                ? coverIndices[position]
+                : null;
+            if (i == null || i >= _filteredItems.length) return null;
+            final item = _filteredItems[i];
+            if (item.cover.isEmpty) return null;
+            try {
+              final response = await ImageHttpClient.instance.fetchImage(
+                item.cover,
+                siteBaseUrl: _currentSite?.baseUrl,
+                siteCookie: _currentSite?.cookie,
+              );
+              return response.data == null
+                  ? null
+                  : Uint8List.fromList(response.data!);
+            } catch (_) {
+              return null;
+            }
+          },
+          onPageChanged: (position) {
+            if (position < 0 || position >= coverIndices.length) return;
+            final i = coverIndices[position];
+            if (i < _filteredItems.length) {
+              _listScroller.scrollToIndex(i);
+            }
+          },
+        );
+      },
+    );
+  }
+
   void _onTorrentTap(TorrentItem item) async {
     // 检查站点是否支持种子详情功能
     if (_currentSite?.features.supportTorrentDetail == false) {
@@ -3090,6 +3158,8 @@ class _HomePageState extends State<HomePage> {
                                         ),
                                         onRetryBatchAction:
                                             _buildRetryCallbackForItem(item),
+                                        onCoverTap: () =>
+                                            _openCoverGallery(index),
                                         onTap: () => _isSelectionMode
                                             ? _onToggleSelection(item, index)
                                             : _onTorrentTap(item),

--- a/lib/pages/aggregate_search_page.dart
+++ b/lib/pages/aggregate_search_page.dart
@@ -8,6 +8,7 @@ import '../models/app_models.dart';
 import '../models/batch_operation_models.dart';
 import '../services/storage/storage_service.dart';
 import '../services/api/api_service.dart';
+import '../services/image_http_client.dart';
 import '../services/settings/display_settings_manager.dart';
 import '../services/aggregate_search_service.dart';
 import '../services/theme/app_tokens.dart';
@@ -21,6 +22,8 @@ import '../widgets/batch_progress_card.dart';
 import '../widgets/responsive_layout.dart';
 import '../widgets/qb_speed_indicator.dart';
 import '../widgets/torrent_list_item.dart';
+import '../widgets/torrent_cover_gallery_viewer.dart';
+import '../widgets/list_index_scroller.dart';
 import '../widgets/torrent_download_dialog.dart';
 import '../widgets/tag_filter_bar.dart';
 import '../widgets/aggregate_search_strategy_list.dart';
@@ -53,6 +56,10 @@ class _AggregateSearchPageState extends State<AggregateSearchPage> {
   final GlobalKey _listKey = GlobalKey();
 
   final ScrollController _listController = ScrollController();
+  late final ListIndexScroller _listScroller = ListIndexScroller(
+    controller: _listController,
+    listViewKey: _listKey,
+  );
 
   // String? _overlaySiteName; // Moved to _AggregateSearchScrollbar
   // double _overlayOpacity = 0.0; // Moved to _AggregateSearchScrollbar
@@ -667,6 +674,8 @@ class _AggregateSearchPageState extends State<AggregateSearchPage> {
                                                       _buildRetryCallbackForItem(
                                                         item,
                                                       ),
+                                                  onCoverTap: () =>
+                                                      _openCoverGallery(index),
                                                   suspendImageLoading:
                                                       _isFastScrolling,
                                                   onTap: _isSelectionMode
@@ -1167,6 +1176,82 @@ class _AggregateSearchPageState extends State<AggregateSearchPage> {
         NotificationHelper.showError(context, '搜索失败：$e');
       }
     }
+  }
+
+  /// 打开封面画廊查看器，可左右翻页并联动滚动列表。
+  void _openCoverGallery(int listIndex) {
+    final provider = Provider.of<AggregateSearchProvider>(
+      context,
+      listen: false,
+    );
+    final items = provider.filteredResults;
+    if (listIndex < 0 || listIndex >= items.length) return;
+    if (items[listIndex].torrent.cover.isEmpty) return;
+
+    final coverIndices = <int>[
+      for (var i = 0; i < items.length; i++)
+        if (items[i].torrent.cover.isNotEmpty) i,
+    ];
+    final initialPosition = coverIndices.indexOf(listIndex);
+    if (initialPosition == -1) return;
+
+    showDialog(
+      context: context,
+      barrierColor: Colors.black.withValues(alpha: 0.7),
+      builder: (dialogContext) {
+        return TorrentCoverGalleryViewer(
+          itemCount: coverIndices.length,
+          initialIndex: initialPosition,
+          titleFor: (position) {
+            final i = (position >= 0 && position < coverIndices.length)
+                ? coverIndices[position]
+                : null;
+            return (i != null && i < items.length) ? items[i].torrent.name : '';
+          },
+          loadCover: (position) async {
+            final i = (position >= 0 && position < coverIndices.length)
+                ? coverIndices[position]
+                : null;
+            if (i == null || i >= items.length) return null;
+            final item = items[i];
+            if (item.torrent.cover.isEmpty) return null;
+            SiteConfig? siteConfig;
+            try {
+              final storage = Provider.of<StorageService>(
+                context,
+                listen: false,
+              );
+              final sites = storage.siteConfigsCache ?? [];
+              for (final s in sites) {
+                if (s.id == item.siteId) {
+                  siteConfig = s;
+                  break;
+                }
+              }
+            } catch (_) {}
+            try {
+              final response = await ImageHttpClient.instance.fetchImage(
+                item.torrent.cover,
+                siteBaseUrl: siteConfig?.baseUrl,
+                siteCookie: siteConfig?.cookie,
+              );
+              return response.data == null
+                  ? null
+                  : Uint8List.fromList(response.data!);
+            } catch (_) {
+              return null;
+            }
+          },
+          onPageChanged: (position) {
+            if (position < 0 || position >= coverIndices.length) return;
+            final i = coverIndices[position];
+            if (i < items.length) {
+              _listScroller.scrollToIndex(i);
+            }
+          },
+        );
+      },
+    );
   }
 
   Future<void> _onTorrentTap(AggregateSearchResultItem item) async {

--- a/lib/widgets/category_filter_dialog.dart
+++ b/lib/widgets/category_filter_dialog.dart
@@ -159,7 +159,11 @@ class _CategoryFilterDialogState extends State<CategoryFilterDialog> {
                           final isSelected = index == _selectedCategoryIndex;
                           return ListTile(
                             key: ValueKey('category-item-$index'),
-                            title: Text(category.displayName),
+                            title: Text(
+                              category.displayName,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
                             leading: Radio<int>(value: index),
                             selected: isSelected,
                             selectedTileColor: Theme.of(context)

--- a/lib/widgets/list_index_scroller.dart
+++ b/lib/widgets/list_index_scroller.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'dart:math' as math;
+
+/// 将 ListView.builder 滚动到指定下标。
+///
+/// 实现策略：
+/// 1. 若目标条目已构建，直接几何计算精确 offset 平滑滚动过去；
+/// 2. 否则基于可见条目的平均高度估算 offset 粗定位 jumpTo，等待下一帧
+///    ListView 懒构建出目标条目后重新校准，直至目标可见（上限 [maxAttempts] 次）。
+///
+/// 使用前提：列表条目需用 `MetaData(metaData: index)` 包裹（两个列表现状均如此）。
+class ListIndexScroller {
+  ListIndexScroller({required this.controller, required this.listViewKey});
+
+  final ScrollController controller;
+  final GlobalKey listViewKey;
+
+  static const int maxAttempts = 5;
+  static const double topInsetRatio = 0.1;
+
+  /// 滚动到 [index]，使该条目位于视口顶部约 10% 处。
+  Future<void> scrollToIndex(int index) async {
+    if (!controller.hasClients || index < 0) return;
+
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      final items = _collectVisibleItems();
+      if (items.isEmpty) return;
+
+      final exact = items[index];
+      if (exact != null) {
+        await _animateToItemTop(exact);
+        return;
+      }
+
+      // 估算平均条目高度做粗定位
+      final avgHeight = _averageItemHeight(items);
+      if (avgHeight == null) return;
+      final position = controller.position;
+      final firstIndex = items.keys.reduce(math.min);
+      final listViewBox =
+          listViewKey.currentContext?.findRenderObject() as RenderBox?;
+      if (listViewBox == null) return;
+      final firstScreenY = items[firstIndex]!
+          .localToGlobal(Offset.zero, ancestor: listViewBox)
+          .dy;
+      final firstContentY = position.pixels + firstScreenY;
+      final targetTop =
+          firstContentY +
+          (index - firstIndex) * avgHeight -
+          position.viewportDimension * topInsetRatio;
+      final clamped = targetTop.clamp(
+        position.minScrollExtent,
+        position.maxScrollExtent,
+      );
+      controller.jumpTo(clamped);
+      // 等待下一帧完成，带超时保护避免测试环境无帧调度时挂起
+      await SchedulerBinding.instance.endOfFrame.timeout(
+        const Duration(milliseconds: 100),
+      );
+      if (!controller.hasClients) return;
+    }
+  }
+
+  /// 收集视口内（含缓存区）已构建条目的 {下标: RenderBox}。
+  Map<int, RenderBox> _collectVisibleItems() {
+    final result = <int, RenderBox>{};
+    final root = listViewKey.currentContext?.findRenderObject();
+    if (root == null) return result;
+
+    void visit(RenderObject node) {
+      if (node is RenderMetaData && node.metaData is int) {
+        result[node.metaData as int] = node;
+      }
+      node.visitChildren(visit);
+    }
+
+    root.visitChildren(visit);
+    return result;
+  }
+
+  double? _averageItemHeight(Map<int, RenderBox> items) {
+    if (items.isEmpty) return null;
+    var total = 0.0;
+    for (final box in items.values) {
+      total += box.size.height;
+    }
+    return total / items.length;
+  }
+
+  Future<void> _animateToItemTop(RenderBox item) async {
+    final position = controller.position;
+    final listViewBox =
+        listViewKey.currentContext?.findRenderObject() as RenderBox?;
+    if (listViewBox == null) return;
+
+    // item 在列表坐标系（未滚动前）中的纵向位置
+    final itemLocalTop = item
+        .localToGlobal(Offset.zero, ancestor: listViewBox)
+        .dy;
+    final itemAbsoluteTop = position.pixels + itemLocalTop;
+    final target =
+        (itemAbsoluteTop - position.viewportDimension * topInsetRatio)
+            .clamp(position.minScrollExtent, position.maxScrollExtent)
+            .toDouble();
+    await controller.animateTo(
+      target,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+}

--- a/lib/widgets/torrent_cover_gallery_viewer.dart
+++ b/lib/widgets/torrent_cover_gallery_viewer.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// 种子封面画廊查看器：支持左右翻页查看相邻种子封面。
+///
+/// 宿主通过 [loadCover] 提供指定位置的数据，通过 [onPageChanged]
+/// 感知翻页（用于联动滚动背后的列表）。
+class TorrentCoverGalleryViewer extends StatefulWidget {
+  final int itemCount;
+  final int initialIndex;
+
+  /// 加载指定位置的封面数据；返回 null 表示无法加载（如条目已被移除）。
+  final Future<Uint8List?> Function(int position) loadCover;
+
+  /// 获取指定位置的种子标题（用于底部信息展示）。
+  final String Function(int position) titleFor;
+
+  /// 翻页回调（position 为新位置）。
+  final ValueChanged<int>? onPageChanged;
+
+  const TorrentCoverGalleryViewer({
+    super.key,
+    required this.itemCount,
+    required this.initialIndex,
+    required this.loadCover,
+    required this.titleFor,
+    this.onPageChanged,
+  });
+
+  @override
+  State<TorrentCoverGalleryViewer> createState() =>
+      _TorrentCoverGalleryViewerState();
+}
+
+class _TorrentCoverGalleryViewerState extends State<TorrentCoverGalleryViewer> {
+  final TransformationController _transformationController =
+      TransformationController();
+  final FocusNode _focusNode = FocusNode();
+
+  late int _position;
+  Uint8List? _imageData;
+  bool _isLoading = true;
+  Object? _error;
+  int _requestToken = 0;
+  bool _neighborsPreloaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _position = widget.initialIndex;
+    _focusNode.requestFocus();
+    _loadCurrent();
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    _transformationController.dispose();
+    super.dispose();
+  }
+
+  void _resetZoom() {
+    _transformationController.value = Matrix4.identity();
+  }
+
+  Future<void> _fetch(int position, {required bool silent}) async {
+    final token = ++_requestToken;
+    if (!silent) {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+        _imageData = null;
+      });
+    }
+    try {
+      final data = await widget.loadCover(position);
+      if (!mounted || token != _requestToken) return;
+      if (!silent) {
+        setState(() {
+          _imageData = data;
+          _isLoading = false;
+          _error = data == null ? 'missing' : null;
+        });
+      }
+    } catch (e) {
+      if (!mounted || token != _requestToken || silent) return;
+      setState(() {
+        _error = e;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _preloadNeighbors() {
+    if (_neighborsPreloaded) return;
+    _neighborsPreloaded = true;
+    // 前一张通常已在内存缓存（用户刚从列表点开），后一张预取即可
+    if (_position + 1 < widget.itemCount) {
+      widget.loadCover(_position + 1).then((_) {}, onError: (_) {});
+    }
+  }
+
+  void _loadCurrent() {
+    _fetch(_position, silent: false);
+    _preloadNeighbors();
+  }
+
+  void _goTo(int position) {
+    if (position < 0 || position >= widget.itemCount) return;
+    if (position == _position) return;
+    setState(() {
+      _position = position;
+    });
+    _resetZoom();
+    _loadCurrent();
+    widget.onPageChanged?.call(position);
+  }
+
+  void _handleKey(KeyEvent event) {
+    if (event is! KeyDownEvent) return;
+    if (event.physicalKey == PhysicalKeyboardKey.arrowLeft) {
+      if (_position > 0) _goTo(_position - 1);
+    } else if (event.physicalKey == PhysicalKeyboardKey.arrowRight) {
+      if (_position + 1 < widget.itemCount) _goTo(_position + 1);
+    }
+  }
+
+  void _onDoubleTapAt(Offset position) {
+    if (_transformationController.value != Matrix4.identity()) {
+      _resetZoom();
+    } else {
+      const double scale = 2.0;
+      final Matrix4 matrix = Matrix4.identity()
+        ..setEntry(0, 3, -position.dx)
+        ..setEntry(1, 3, -position.dy);
+      final Matrix4 scaleMatrix = Matrix4.identity()
+        ..setEntry(0, 0, scale)
+        ..setEntry(1, 1, scale);
+      final Matrix4 translateBack = Matrix4.identity()
+        ..setEntry(0, 3, position.dx)
+        ..setEntry(1, 3, position.dy);
+      _transformationController.value = translateBack * scaleMatrix * matrix;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canPrev = _position > 0;
+    final canNext = _position + 1 < widget.itemCount;
+
+    return KeyboardListener(
+      focusNode: _focusNode,
+      onKeyEvent: _handleKey,
+      child: GestureDetector(
+        onTap: () => Navigator.of(context).pop(),
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          body: Stack(
+            children: [
+              // 半透明遮罩，点击任意空白处关闭
+              const ColoredBox(color: Colors.black54),
+              Center(
+                child: GestureDetector(
+                  onDoubleTapDown: (details) =>
+                      _onDoubleTapAt(details.localPosition),
+                  child: InteractiveViewer(
+                    transformationController: _transformationController,
+                    minScale: 0.5,
+                    maxScale: 5.0,
+                    boundaryMargin: const EdgeInsets.all(double.infinity),
+                    constrained: true,
+                    clipBehavior: Clip.none,
+                    child: _buildImage(),
+                  ),
+                ),
+              ),
+              if (canPrev)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: _NavButton(
+                    icon: Icons.chevron_left,
+                    tooltip: '上一个',
+                    onPressed: () => _goTo(_position - 1),
+                  ),
+                ),
+              if (canNext)
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: _NavButton(
+                    icon: Icons.chevron_right,
+                    tooltip: '下一个',
+                    onPressed: () => _goTo(_position + 1),
+                  ),
+                ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 24),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Container(
+                      color: Colors.black.withValues(alpha: 0.5),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          maxWidth: MediaQuery.of(context).size.width * 0.7,
+                        ),
+                        child: Text(
+                          '${widget.titleFor(_position)}  (${_position + 1} / ${widget.itemCount})',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildImage() {
+    if (_isLoading) {
+      return const Center(
+        child: SizedBox(
+          width: 32,
+          height: 32,
+          child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+        ),
+      );
+    }
+    if (_error != null || _imageData == null) {
+      return const Center(
+        child: Text('图片加载失败', style: TextStyle(color: Colors.white)),
+      );
+    }
+    return Image.memory(
+      _imageData!,
+      fit: BoxFit.contain,
+      errorBuilder: (context, error, stack) => const Center(
+        child: Text('图片加载失败', style: TextStyle(color: Colors.white)),
+      ),
+    );
+  }
+}
+
+class _NavButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  const _NavButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Tooltip(
+        message: tooltip,
+        child: Material(
+          color: Colors.black.withValues(alpha: 0.4),
+          shape: const CircleBorder(),
+          child: InkWell(
+            onTap: onPressed,
+            customBorder: const CircleBorder(),
+            child: SizedBox(
+              width: 48,
+              height: 48,
+              child: Icon(icon, color: Colors.white, size: 28),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/torrent_list_item.dart
+++ b/lib/widgets/torrent_list_item.dart
@@ -1046,26 +1046,27 @@ class _TorrentCoverState extends State<TorrentCover> {
   Widget build(BuildContext context) {
     final torrent = widget.torrent;
     final colorScheme = Theme.of(context).colorScheme;
-    return SizedBox(
-      width: _coverWidth,
-      height: _coverHeight,
-      child: Stack(
-        children: [
-          Container(
-            decoration: BoxDecoration(
-              color: AppPlaceholderColors.bone(colorScheme),
-              borderRadius: BorderRadius.circular(6),
-              border: Border.all(
-                color: colorScheme.outline.withValues(alpha: 0.3),
-                width: 1,
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: torrent.cover.isNotEmpty ? () => _handleTap(context) : null,
+      child: SizedBox(
+        width: _coverWidth,
+        height: _coverHeight,
+        child: Stack(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: AppPlaceholderColors.bone(colorScheme),
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(
+                  color: colorScheme.outline.withValues(alpha: 0.3),
+                  width: 1,
+                ),
               ),
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(6),
-              child: torrent.cover.isNotEmpty
-                  ? GestureDetector(
-                      onTap: () => _handleTap(context),
-                      child: CachedNetworkImage(
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(6),
+                child: torrent.cover.isNotEmpty
+                    ? CachedNetworkImage(
                         key: ValueKey('${torrent.cover}::$_reloadKey'),
                         imageUrl: torrent.cover,
                         siteConfig: widget.currentSite,
@@ -1098,30 +1099,26 @@ class _TorrentCoverState extends State<TorrentCover> {
                             text: '加载失败',
                           );
                         },
+                      )
+                    : _buildCoverPlaceholder(
+                        context,
+                        icon: const Icon(Icons.image_outlined, size: 24),
+                        text: '暂无',
                       ),
-                    )
-                  : _buildCoverPlaceholder(
-                      context,
-                      icon: const Icon(Icons.image_outlined, size: 24),
-                      text: '暂无',
-                    ),
+              ),
             ),
-          ),
-          if (widget.hasDouban || widget.hasImdb)
-            Positioned(
-              left: 0,
-              bottom: 0,
-              child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () => _handleTap(context),
+            if (widget.hasDouban || widget.hasImdb)
+              Positioned(
+                left: 0,
+                bottom: 0,
                 child: _CoverRatingBadges(
                   torrent: torrent,
                   hasDouban: widget.hasDouban,
                   hasImdb: widget.hasImdb,
                 ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/torrent_list_item.dart
+++ b/lib/widgets/torrent_list_item.dart
@@ -856,8 +856,13 @@ class _DiscountBadge extends StatelessWidget {
     final baseText = torrent.discount.displayText;
     final endTime = torrent.discountEndTime;
     if (torrent.discount != DiscountType.normal && endTime != null) {
-      final hoursLeft = endTime.difference(DateTime.now()).inHours;
-      if (hoursLeft > 0) return '$baseText ${hoursLeft}h';
+      final remaining = endTime.difference(DateTime.now());
+      if (remaining.inMicroseconds > 0) {
+        if (remaining.inHours >= 1) {
+          return '$baseText ${remaining.inHours}h';
+        }
+        return '$baseText ${remaining.inMinutes}m';
+      }
     }
     return baseText;
   }

--- a/lib/widgets/torrent_list_item.dart
+++ b/lib/widgets/torrent_list_item.dart
@@ -91,6 +91,10 @@ class TorrentListItem extends StatelessWidget {
 
   /// 下载回调
   final VoidCallback? onDownload;
+
+  /// 点击封面回调；为 null 时保留内置的全屏预览行为
+  final VoidCallback? onCoverTap;
+
   final BatchOperationType? batchOperationType;
   final BatchItemState batchItemState;
   final String? batchErrorMessage;
@@ -108,6 +112,7 @@ class TorrentListItem extends StatelessWidget {
     this.onLongPress,
     this.onToggleCollection,
     this.onDownload,
+    this.onCoverTap,
     this.suspendImageLoading,
     this.showCoverSetting,
     this.batchOperationType,
@@ -203,6 +208,7 @@ class TorrentListItem extends StatelessWidget {
                       onRetryBatchAction: onRetryBatchAction,
                       onToggleCollection: onToggleCollection,
                       onDownload: onDownload,
+                      onCoverTap: onCoverTap,
                       aggregateSiteColor: aggregateSiteColor,
                     ),
                   ),
@@ -378,6 +384,7 @@ class _TorrentListItemRow extends StatelessWidget {
   final VoidCallback? onRetryBatchAction;
   final VoidCallback? onToggleCollection;
   final VoidCallback? onDownload;
+  final VoidCallback? onCoverTap;
   final Color? aggregateSiteColor;
 
   const _TorrentListItemRow({
@@ -397,6 +404,7 @@ class _TorrentListItemRow extends StatelessWidget {
     this.onRetryBatchAction,
     this.onToggleCollection,
     this.onDownload,
+    this.onCoverTap,
     this.aggregateSiteColor,
   });
 
@@ -415,6 +423,7 @@ class _TorrentListItemRow extends StatelessWidget {
             isMobile: isMobile,
             hasDouban: hasDouban,
             hasImdb: hasImdb,
+            onTap: onCoverTap,
           ),
         Expanded(
           child: TorrentInfo(
@@ -961,6 +970,9 @@ class TorrentCover extends StatefulWidget {
   final bool hasDouban;
   final bool hasImdb;
 
+  /// 点击封面回调；为 null 时使用内置全屏预览
+  final VoidCallback? onTap;
+
   const TorrentCover({
     super.key,
     required this.torrent,
@@ -968,6 +980,7 @@ class TorrentCover extends StatefulWidget {
     required this.isMobile,
     required this.hasDouban,
     required this.hasImdb,
+    this.onTap,
   });
 
   @override
@@ -1013,6 +1026,11 @@ class _TorrentCoverState extends State<TorrentCover> {
 
   void _handleTap(BuildContext context) {
     if (widget.torrent.cover.isEmpty) return;
+    if (widget.onTap != null) {
+      FocusManager.instance.primaryFocus?.unfocus();
+      widget.onTap!();
+      return;
+    }
     final data = _imageData;
     if (data != null) {
       _showCoverPreview(context, data);

--- a/test/widgets/category_filter_dialog_test.dart
+++ b/test/widgets/category_filter_dialog_test.dart
@@ -96,6 +96,25 @@ void main() {
     );
   });
 
+  testWidgets('limits long category names to two lines', (tester) async {
+    const longCategoryName = '这是一个非常长的分类名称用于验证分类标题最多只会显示两行内容';
+    await _openDialog(
+      tester,
+      categories: const [
+        SearchCategoryConfig(
+          id: 'long-category',
+          displayName: longCategoryName,
+          parameters: '{}',
+        ),
+      ],
+      selectedCategoryIndex: 0,
+    );
+
+    final categoryTitle = tester.widget<Text>(find.text(longCategoryName));
+    expect(categoryTitle.maxLines, 2);
+    expect(categoryTitle.overflow, TextOverflow.ellipsis);
+  });
+
   testWidgets('handles an invalid category selection', (tester) async {
     await _openDialog(
       tester,

--- a/test/widgets/list_index_scroller_test.dart
+++ b/test/widgets/list_index_scroller_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pt_mate/widgets/list_index_scroller.dart';
+
+void main() {
+  testWidgets('scrollToIndex 将远端条目滚动到可见区域', (tester) async {
+    final controller = ScrollController();
+    final listKey = GlobalKey();
+    final scroller = ListIndexScroller(
+      controller: controller,
+      listViewKey: listKey,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ListView.builder(
+            key: listKey,
+            controller: controller,
+            itemCount: 100,
+            itemBuilder: (context, index) => MetaData(
+              metaData: index,
+              behavior: HitTestBehavior.translucent,
+              child: SizedBox(
+                height: 60,
+                child: Text('Item $index', key: ValueKey('item-$index')),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Item 50', skipOffstage: false), findsNothing);
+
+    final future = scroller.scrollToIndex(50);
+    // 驱动帧调度，让 endOfFrame 能完成
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    await future;
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 50', skipOffstage: false), findsOneWidget);
+
+    controller.dispose();
+  });
+
+  testWidgets('目标已在视口内时平滑滚动对齐顶部', (tester) async {
+    final controller = ScrollController();
+    final listKey = GlobalKey();
+    final scroller = ListIndexScroller(
+      controller: controller,
+      listViewKey: listKey,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 300,
+            child: ListView.builder(
+              key: listKey,
+              controller: controller,
+              itemCount: 50,
+              itemBuilder: (context, index) => MetaData(
+                metaData: index,
+                behavior: HitTestBehavior.translucent,
+                child: SizedBox(height: 60, child: Text('Item $index')),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final future = scroller.scrollToIndex(3);
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    await future;
+    await tester.pumpAndSettle();
+
+    // 3 * 60 - 300 * 0.1 = 150
+    expect(controller.offset, closeTo(150, 1));
+
+    controller.dispose();
+  });
+}

--- a/test/widgets/torrent_cover_gallery_viewer_test.dart
+++ b/test/widgets/torrent_cover_gallery_viewer_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:pt_mate/widgets/torrent_cover_gallery_viewer.dart';
+
+Uint8List _png(Color color) {
+  final image = img.Image(width: 4, height: 4);
+  img.fill(
+    image,
+    color: img.ColorRgba8(
+      (color.r * 255.0).round().clamp(0, 255),
+      (color.g * 255.0).round().clamp(0, 255),
+      (color.b * 255.0).round().clamp(0, 255),
+      255,
+    ),
+  );
+  return Uint8List.fromList(img.encodePng(image));
+}
+
+void main() {
+  final images = <Uint8List>[
+    _png(const Color(0xFFFF0000)),
+    _png(const Color(0xFF00FF00)),
+    _png(const Color(0xFF0000FF)),
+  ];
+
+  Future<Uint8List?> loadCover(int position) async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    if (position < 0 || position >= images.length) return null;
+    return images[position];
+  }
+
+  Widget buildViewer({int initialIndex = 0, ValueChanged<int>? onPageChanged}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: TorrentCoverGalleryViewer(
+          itemCount: images.length,
+          initialIndex: initialIndex,
+          loadCover: loadCover,
+          titleFor: (p) => 'Title $p',
+          onPageChanged: onPageChanged,
+        ),
+      ),
+    );
+  }
+
+  testWidgets('初始加载显示第一张图与位置指示', (tester) async {
+    await tester.pumpWidget(buildViewer());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(find.text('Title 0  (1 / 3)'), findsOneWidget);
+    // 第一张时左侧按钮隐藏（不可后退）
+    expect(find.byTooltip('上一个'), findsNothing);
+    expect(find.byTooltip('下一个'), findsOneWidget);
+  });
+
+  testWidgets('点击右侧按钮翻到下一张并触发回调', (tester) async {
+    var changed = -1;
+    await tester.pumpWidget(buildViewer(onPageChanged: (p) => changed = p));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('下一个'));
+    await tester.pumpAndSettle();
+
+    expect(changed, 1);
+    expect(find.text('Title 1  (2 / 3)'), findsOneWidget);
+    expect(find.byTooltip('上一个'), findsOneWidget);
+    expect(find.byTooltip('下一个'), findsOneWidget);
+  });
+
+  testWidgets('最后一张时右侧按钮隐藏', (tester) async {
+    await tester.pumpWidget(buildViewer(initialIndex: 2));
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('上一个'), findsOneWidget);
+    expect(find.byTooltip('下一个'), findsNothing);
+  });
+
+  testWidgets('方向键可以翻页', (tester) async {
+    var changed = -1;
+    await tester.pumpWidget(buildViewer(onPageChanged: (p) => changed = p));
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+
+    expect(changed, 1);
+  });
+
+  testWidgets('加载失败时显示错误并可继续翻页', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TorrentCoverGalleryViewer(
+            itemCount: 2,
+            initialIndex: 0,
+            loadCover: (p) async => p == 0 ? null : images[1],
+            titleFor: (p) => 'T$p',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('图片加载失败'), findsOneWidget);
+    await tester.tap(find.byTooltip('下一个'));
+    await tester.pumpAndSettle();
+    expect(find.byType(Image), findsOneWidget);
+  });
+}

--- a/test/widgets/torrent_cover_retry_test.dart
+++ b/test/widgets/torrent_cover_retry_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pt_mate/models/app_models.dart';
+import 'package:pt_mate/widgets/cached_network_image.dart';
+import 'package:pt_mate/widgets/torrent_list_item.dart';
+
+void main() {
+  testWidgets('点击封面空白区域也会重新加载图片', (tester) async {
+    const coverUrl = 'https://example.invalid/cover.jpg';
+    final torrent = TorrentItem(
+      id: 'cover-retry',
+      name: 'Cover retry test',
+      smallDescr: '',
+      sizeBytes: 0,
+      seeders: 0,
+      leechers: 0,
+      createdDate: DateTime(2026),
+      discountEndTime: null,
+      downloadUrl: '',
+      imageList: const [],
+      cover: coverUrl,
+      downloadStatus: DownloadStatus.none,
+      discount: DiscountType.normal,
+      collection: false,
+      isTop: false,
+      tags: const [],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TorrentCover(
+            torrent: torrent,
+            isMobile: true,
+            hasDouban: false,
+            hasImdb: false,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('$coverUrl::0')), findsOneWidget);
+
+    final coverRect = tester.getRect(find.byType(TorrentCover));
+    await tester.tapAt(coverRect.topLeft + const Offset(2, 2));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('$coverUrl::1')), findsOneWidget);
+
+    await tester.tapAt(coverRect.bottomRight - const Offset(2, 2));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('$coverUrl::2')), findsOneWidget);
+    expect(find.byType(CachedNetworkImage), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 1));
+  });
+}

--- a/test/widgets/torrent_list_item_cover_tap_test.dart
+++ b/test/widgets/torrent_list_item_cover_tap_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pt_mate/models/app_models.dart';
+import 'package:pt_mate/widgets/torrent_list_item.dart';
+
+void main() {
+  TorrentItem buildTorrent({String cover = 'https://example.invalid/c.jpg'}) {
+    return TorrentItem(
+      id: 't1',
+      name: 'Cover tap test',
+      smallDescr: '',
+      sizeBytes: 0,
+      seeders: 0,
+      leechers: 0,
+      createdDate: DateTime(2026),
+      discountEndTime: null,
+      downloadUrl: '',
+      imageList: const [],
+      cover: cover,
+      downloadStatus: DownloadStatus.none,
+      discount: DiscountType.normal,
+      collection: false,
+      isTop: false,
+      tags: const [],
+    );
+  }
+
+  testWidgets('设置 onCoverTap 时点击封面触发回调', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TorrentCover(
+            torrent: buildTorrent(),
+            isMobile: true,
+            hasDouban: false,
+            hasImdb: false,
+            onTap: () => tapped = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(TorrentCover));
+    await tester.pump();
+
+    expect(tapped, isTrue);
+    await tester.pump(const Duration(milliseconds: 1));
+  });
+
+  testWidgets('未设置 onCoverTap 时点击封面走内置重载逻辑', (tester) async {
+    const coverUrl = 'https://example.invalid/builtin.jpg';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TorrentCover(
+            torrent: buildTorrent(cover: coverUrl),
+            isMobile: true,
+            hasDouban: false,
+            hasImdb: false,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('$coverUrl::0')), findsOneWidget);
+    await tester.tap(find.byType(TorrentCover));
+    await tester.pump();
+    // 内置行为：无缓存数据时点击会触发重载（reloadKey 递增）
+    expect(find.byKey(const ValueKey('$coverUrl::1')), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 1));
+  });
+}

--- a/test/widgets/torrent_list_item_layout_test.dart
+++ b/test/widgets/torrent_list_item_layout_test.dart
@@ -47,6 +47,86 @@ void main() {
     );
   }
 
+  TorrentItem createDiscountTorrent({DateTime? discountEndTime}) {
+    return TorrentItem(
+      id: 'discount-test',
+      name: 'Discount Test Torrent',
+      smallDescr: '',
+      sizeBytes: 1024,
+      seeders: 1,
+      leechers: 0,
+      createdDate: DateTime.parse('2023-10-27T10:00:00Z'),
+      discountEndTime: discountEndTime,
+      downloadUrl: '',
+      imageList: const [],
+      cover: '',
+      downloadStatus: DownloadStatus.none,
+      discount: DiscountType.free,
+      collection: false,
+      isTop: false,
+      doubanRating: '0',
+      imdbRating: '0',
+      tags: const [],
+    );
+  }
+
+  testWidgets('discount badge formats remaining hours and minutes', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      createWidgetUnderTest(
+        width: 360,
+        torrent: createDiscountTorrent(
+          discountEndTime: DateTime.now().add(
+            const Duration(hours: 1, minutes: 59),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('FREE 1h'), findsOneWidget);
+
+    await tester.pumpWidget(
+      createWidgetUnderTest(
+        width: 360,
+        torrent: createDiscountTorrent(
+          discountEndTime: DateTime.now().add(
+            const Duration(minutes: 35, seconds: 30),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('FREE 35m'), findsOneWidget);
+
+    await tester.pumpWidget(
+      createWidgetUnderTest(
+        width: 360,
+        torrent: createDiscountTorrent(
+          discountEndTime: DateTime.now().add(const Duration(seconds: 30)),
+        ),
+      ),
+    );
+    expect(find.text('FREE 0m'), findsOneWidget);
+  });
+
+  testWidgets('discount badge omits time when expired or without end time', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      createWidgetUnderTest(
+        width: 360,
+        torrent: createDiscountTorrent(
+          discountEndTime: DateTime.now().subtract(const Duration(seconds: 1)),
+        ),
+      ),
+    );
+    expect(find.text('FREE'), findsOneWidget);
+
+    await tester.pumpWidget(
+      createWidgetUnderTest(width: 360, torrent: createDiscountTorrent()),
+    );
+    expect(find.text('FREE'), findsOneWidget);
+  });
+
   testWidgets('mobile torrent size stays on one line on narrow screens', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## 变更摘要

本 PR 包含封面浏览体验相关的多项改进：

- **feat: 封面查看器支持左右翻页并联动滚动列表** —— 在封面查看器中支持左右滑动翻页，并与滚动列表联动同步当前条目
- **fix: 扩大封面加载失败重试点击区域** —— 提升封面加载失败后重试的可操作性
- **fix: 支持优惠标签分钟倒计时** —— 优惠标签支持按分钟粒度的倒计时展示
- **fix: limit category names to two lines** —— 分类名称限制为最多两行显示

## 开发影响

改进封面浏览、查看与列表联动的交互体验，并修复若干 UI 细节问题。

## 验证

- `flutter analyze`：0 issues
- `flutter test`：349 个测试全部通过（含 1 个跳过）

## 备注

工作区中有一处未提交的 `analysis_options.yaml` 修改（排除平台目录），未包含在本 PR 中。
